### PR TITLE
Introduce request-channel support for Requester and Responder RSockets

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketClient.kt
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketClient.kt
@@ -16,28 +16,34 @@
 
 package io.rsocket
 
+import io.rsocket.util.ExceptionUtil.noStacktrace
+
 import io.netty.buffer.Unpooled
 import io.netty.util.collection.IntObjectHashMap
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.disposables.Disposable
+import io.reactivex.functions.Consumer
 import io.reactivex.processors.AsyncProcessor
+import io.reactivex.processors.FlowableProcessor
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.processors.UnicastProcessor
 import io.rsocket.exceptions.ConnectionException
 import io.rsocket.exceptions.Exceptions
-import io.rsocket.internal.LimitedRequestPublisher
-import io.rsocket.util.ExceptionUtil.noStacktrace
+import io.rsocket.internal.LimitableRequestPublisher
 import io.rsocket.util.PayloadImpl
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
+
 import java.nio.channels.ClosedChannelException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeUnit
 
 /** Client Side of a RSocket socket. Sends [Frame]s to a [RSocketServer]  */
-internal class RSocketClient @JvmOverloads constructor(
+internal open class RSocketClient @JvmOverloads constructor(
         private val connection: DuplexConnection,
         private val errorConsumer: (Throwable) -> Unit,
         private val streamIdSupplier: StreamIdSupplier,
@@ -46,237 +52,312 @@ internal class RSocketClient @JvmOverloads constructor(
         missedAcks: Int = 0) : RSocket {
     private val started: AsyncProcessor<Void> = AsyncProcessor.create()
     private val completeOnStart = started.ignoreElements()
-
-    private val senders: IntObjectHashMap<LimitedRequestPublisher<*>> = IntObjectHashMap(256, 0.9f)
+    private val senders: IntObjectHashMap<LimitableRequestPublisher<*>> = IntObjectHashMap(256, 0.9f)
     private val receivers: IntObjectHashMap<Subscriber<Payload>> = IntObjectHashMap(256, 0.9f)
     private val missedAckCounter: AtomicInteger = AtomicInteger()
-    @Volatile private var sendError = false
-    private val sendProcessor: PublishProcessor<Frame> = PublishProcessor.create()
+
+    private val sendProcessor: FlowableProcessor<Frame> = PublishProcessor
+            .create<Frame>()
+            .toSerialized()
 
     private var keepAliveSendSub: Disposable? = null
     @Volatile private var timeLastTickSentMs: Long = 0
 
     init {
-
-        // DO NOT Change the order here. The Send processor must be subscribed to before receiving connections
-
+        // DO NOT Change the order here. The Send processor must be subscribed to before receiving
         if (Duration.ZERO != tickPeriod) {
             val ackTimeoutMs = ackTimeout.toMillis
 
-            this.keepAliveSendSub = completeOnStart
-                    .andThen (Flowable.interval(tickPeriod.value,tickPeriod.unit))
-                    .doOnSubscribe { s -> timeLastTickSentMs = System.currentTimeMillis() }
-                    .flatMapCompletable { i -> sendKeepAlive(ackTimeoutMs, missedAcks) }
-                    .doOnError { t ->
-                        errorConsumer(t)
-                        connection.close().subscribe()
-                    }
+            this.keepAliveSendSub = started
+                    .flatMap{ _ -> Flowable.interval(tickPeriod.toMillis,TimeUnit.SECONDS)}
+                    .doOnSubscribe({ _ -> timeLastTickSentMs = System.currentTimeMillis() })
+                    .concatMap({ _ -> sendKeepAlive(ackTimeoutMs, missedAcks).toFlowable<Long>() })
+                    .doOnError({ t:Throwable ->
+                                errorConsumer(t)
+                                connection.close().subscribe()
+                            })
                     .subscribe()
         }
 
-        connection.onClose().doFinally { cleanup() }.doOnError(errorConsumer).subscribe()
+        connection
+                .onClose()
+                .doFinally { cleanup() }
+                .doOnError(errorConsumer)
+                .subscribe()
 
         connection
                 .send(sendProcessor)
                 .doOnError { handleSendProcessorError(it) }
-                .doFinally { handleSendProcessorCancel() }
                 .subscribe()
 
         connection
                 .receive()
-                .doOnSubscribe { subscription -> started.onComplete() }
-                .doOnNext { this.handleIncomingFrames(it) }
+                .doOnSubscribe { started.onComplete() }
+                .doOnNext { handleIncomingFrames(it) }
                 .doOnError(errorConsumer)
                 .subscribe()
     }
 
     private fun handleSendProcessorError(t: Throwable) {
-        sendError = true
-        val (values, values1) = synchronized(this@RSocketClient) {
+        val (receivers, senders) = synchronized(this) {
             Pair(receivers.values, senders.values)
         }
-
-        for (subscriber in values) {
+        for (subscriber in receivers) {
             try {
                 subscriber.onError(t)
             } catch (e: Throwable) {
                 errorConsumer(e)
             }
-
         }
 
-        for (p in values1) {
-            p.cancel()
-        }
-    }
-
-    private fun handleSendProcessorCancel() {
-        if (sendError) return
-
-        val (values, values1) = synchronized(this@RSocketClient) {
-            Pair(receivers.values, senders.values)
-        }
-
-        for (subscriber in values) {
-            try {
-                subscriber.onError(Throwable("closed connection"))
-            } catch (e: Throwable) {
-                errorConsumer(e)
-            }
-        }
-
-        for (p in values1) {
+        for (p in senders) {
             p.cancel()
         }
     }
 
     private fun sendKeepAlive(ackTimeoutMs: Long, missedAcks: Int): Completable {
         return Completable.fromRunnable {
-            val now = System.currentTimeMillis()
-            if (now - timeLastTickSentMs > ackTimeoutMs) {
-                val count = missedAckCounter.incrementAndGet()
-                if (count >= missedAcks) {
-                    val message = String.format(
-                            "Missed %d keep-alive acks with a threshold of %d and a ack timeout of %d ms",
-                            count, missedAcks, ackTimeoutMs)
-                    throw ConnectionException(message)
-                }
-            }
+                    val now = System.currentTimeMillis()
+                    if (now - timeLastTickSentMs > ackTimeoutMs) {
+                        val count = missedAckCounter.incrementAndGet()
+                        if (count >= missedAcks) {
+                            val message = String.format(
+                                    "Missed %d keep-alive acks with a threshold of %d and a ack timeout of %d ms",
+                                    count, missedAcks, ackTimeoutMs)
+                            throw ConnectionException(message)
+                        }
+                    }
 
-            sendProcessor.onNext(Frame.Keepalive.from(Unpooled.EMPTY_BUFFER, true))
-        }
+                    sendProcessor.onNext(Frame.Keepalive.from(Unpooled.EMPTY_BUFFER, true))
+                }
     }
 
     override fun fireAndForget(payload: Payload): Completable {
         val defer = Completable.fromRunnable {
-            val streamId = streamIdSupplier.nextStreamId()
-            val requestFrame = Frame.Request.from(streamId, FrameType.FIRE_AND_FORGET, payload, 1)
-            sendProcessor.onNext(requestFrame)
-        }
+                    val streamId = streamIdSupplier.nextStreamId()
+                    val requestFrame = Frame.Request.from(
+                            streamId,
+                            FrameType.FIRE_AND_FORGET,
+                            payload,
+                            1)
+                    sendProcessor.onNext(requestFrame)
+                }
 
         return completeOnStart.andThen(defer)
     }
 
-    override fun requestResponse(payload: Payload): Single<Payload> {
-        return handleRequestResponse(payload)
-    }
+    override fun requestResponse(payload: Payload): Single<Payload> =
+            handleRequestResponse(payload)
 
-    override fun requestStream(payload: Payload): Flowable<Payload> {
-        return handleRequestStream(payload)
-    }
+    override fun requestStream(payload: Payload): Flowable<Payload> =
+            handleRequestStream(payload)
 
-    override fun requestChannel(payloads: Publisher<Payload>): Flowable<Payload> {
-        return Flowable.error(UnsupportedOperationException("not implemented"))
-    }
+    override fun requestChannel(payloads: Publisher<Payload>): Flowable<Payload> =
+            handleChannel(Flowable.fromPublisher(payloads), FrameType.REQUEST_CHANNEL)
 
     override fun metadataPush(payload: Payload): Completable {
-        val requestFrame = Frame.Request.from(0, FrameType.METADATA_PUSH, payload, 1)
+        val requestFrame = Frame.Request.from(
+                0,
+                FrameType.METADATA_PUSH,
+                payload,
+                1)
         sendProcessor.onNext(requestFrame)
         return Completable.complete()
     }
 
-    override fun availability(): Double {
-        return connection.availability()
-    }
+    override fun availability(): Double = connection.availability()
 
-    override fun close(): Completable {
-        return connection.close()
-    }
+    override fun close(): Completable = connection.close()
 
-    override fun onClose(): Completable {
-        return connection.onClose()
-    }
+    override fun onClose(): Completable = connection.onClose()
 
-    fun handleRequestStream(payload: Payload): Flowable<Payload> {
+    private fun handleRequestStream(payload: Payload): Flowable<Payload> {
         return completeOnStart.andThen(
                 Flowable.defer {
-                    val streamId = streamIdSupplier.nextStreamId()
-
-                    val receiver = UnicastProcessor.create<Payload>()
-
-                    synchronized(this) {
-                        receivers.put(streamId, receiver)
-                    }
-
-                    val first = AtomicBoolean(false)
-
-                    receiver
-                            .doOnRequest { l ->
-                                if (first.compareAndSet(false, true)) {
-                                    val requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_STREAM, payload, l)
-
-                                    sendProcessor.onNext(requestFrame)
-                                } else if (contains(streamId)
-                                        && connection.availability() > 0.0) {
-                                    sendProcessor.onNext(Frame.RequestN.from(streamId, l))
-                                }
+                            val streamId = streamIdSupplier.nextStreamId()
+                            val receiver = UnicastProcessor.create<Payload>()
+                            synchronized(this) {
+                                receivers.put(streamId, receiver)
                             }
-                            .doOnError { t ->
-                                if (contains(streamId)
-                                        && connection.availability() > 0.0) {
-                                    sendProcessor.onNext(Frame.Error.from(streamId, t))
-                                }
-                            }
-                            .doOnCancel {
-                                if (contains(streamId)
-                                        && connection.availability() > 0.0) {
-                                    sendProcessor.onNext(Frame.Cancel.from(streamId))
-                                }
-                            }
-                            .doFinally { removeReceiver(streamId) }
-                })
+
+                            val first = AtomicBoolean(false)
+
+                            receiver
+                                    .doOnRequest{ l ->
+                                                if (first.compareAndSet(false, true) && !receiver.isTerminated()) {
+                                                    val requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_STREAM, payload, l)
+                                                    sendProcessor.onNext(requestFrame)
+                                                } else if (contains(streamId)) {
+                                                    sendProcessor.onNext(Frame.RequestN.from(streamId, l))
+                                                }
+                                            }
+                                    .doOnError { t ->
+                                                if (contains(streamId) && !receiver.isTerminated()) {
+                                                    sendProcessor.onNext(Frame.Error.from(streamId, t))
+                                                }
+                                            }
+                                    .doOnCancel {
+                                                if (contains(streamId) && !receiver.isTerminated()) {
+                                                    sendProcessor.onNext(Frame.Cancel.from(streamId))
+                                                }
+                                            }
+                                    .doFinally { removeReceiver(streamId) }
+                        })
     }
 
     private fun handleRequestResponse(payload: Payload): Single<Payload> {
         return completeOnStart.andThen(
-                Single.defer {
-                    val streamId = streamIdSupplier.nextStreamId()
-                    val requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1)
+                Single.defer(
+                        {
+                            val streamId = streamIdSupplier.nextStreamId()
+                            val requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1)
 
-                    val receiver = AsyncProcessor.create<Payload>()
+                            val receiver = PublishProcessor.create<Payload>()
 
-                    synchronized(this) {
-                        receivers.put(streamId, receiver)
-                    }
+                            synchronized(this) {
+                                receivers.put(streamId, receiver)
+                            }
 
-                    sendProcessor.onNext(requestFrame)
+                            sendProcessor.onNext(requestFrame)
 
-                    receiver
-                            .doOnError { t -> sendProcessor.onNext(Frame.Error.from(streamId, t)) }
-                            .doOnCancel { sendProcessor.onNext(Frame.Cancel.from(streamId)) }
-                            .doFinally { removeReceiver(streamId) }
-                            .firstOrError()
-                })
+                            receiver
+                                    .doOnError{ t -> sendProcessor.onNext(Frame.Error.from(streamId, t)) }
+                                    .doOnCancel{ sendProcessor.onNext(Frame.Cancel.from(streamId)) }
+                                    .doFinally { removeReceiver(streamId) }
+                                    .firstOrError()
+                        }))
+    }
+
+    private fun handleChannel(request: Flowable<Payload>, requestType: FrameType): Flowable<Payload> {
+        return completeOnStart.andThen(
+                Flowable.defer(
+                        object : () -> Flowable<Payload> {
+                            internal val receiver = UnicastProcessor.create<Payload>()
+                            internal val streamId = streamIdSupplier.nextStreamId()
+                            internal var firstRequest = true
+
+                            internal val isValidToSendFrame: Boolean
+                                get() = contains(streamId) && !receiver.isTerminated()
+
+                            internal fun sendOneFrame(frame: Frame) {
+                                if (isValidToSendFrame) {
+                                    sendProcessor.onNext(frame)
+                                }
+                            }
+
+                            override fun invoke(): Flowable<Payload> {
+                                return receiver
+                                        .doOnRequest(
+                                                { l ->
+                                                    var _firstRequest = false
+                                                    synchronized(this) {
+                                                        if (firstRequest) {
+                                                            _firstRequest = true
+                                                            firstRequest = false
+                                                        }
+                                                    }
+
+                                                    if (_firstRequest) {
+                                                        val firstPayload = AtomicBoolean(true)
+                                                        val requestFrames = request
+                                                                .compose { f ->
+                                                                    val wrapped = LimitableRequestPublisher.wrap(f)
+                                                                    // Need to set this to one for first the frame
+                                                                    wrapped.increaseRequestLimit(1)
+                                                                    synchronized(this) {
+                                                                        senders.put(streamId, wrapped)
+                                                                        receivers.put(streamId, receiver)
+                                                                    }
+                                                                    wrapped
+                                                                }
+                                                                .map { payload ->
+                                                                    val requestFrame: Frame =
+                                                                            if (firstPayload.compareAndSet(true, false)) {
+                                                                                Frame.Request.from(
+                                                                                        streamId, requestType, payload, l)
+                                                                            } else {
+                                                                                Frame.PayloadFrame.from(
+                                                                                        streamId, FrameType.NEXT, payload)
+                                                                            }
+                                                                    requestFrame
+                                                                }
+                                                                .doOnComplete {
+                                                                    if (FrameType.REQUEST_CHANNEL === requestType) {
+                                                                        sendOneFrame(
+                                                                                Frame.PayloadFrame.from(
+                                                                                        streamId, FrameType.COMPLETE))
+                                                                        if (firstPayload.get()) {
+                                                                            receiver.onComplete()
+                                                                        }
+                                                                    }
+                                                                }
+
+                                                        requestFrames
+                                                                .doOnNext { sendProcessor.onNext(it) }
+                                                                .doOnError { t ->
+                                                                    errorConsumer(t)
+                                                                    receiver.onError(CancellationException("Disposed"))
+                                                                }.subscribe()
+                                                    } else {
+                                                        sendOneFrame(Frame.RequestN.from(streamId, l))
+                                                    }
+                                                })
+                                        .doOnError { t -> sendOneFrame(Frame.Error.from(streamId, t)) }
+                                        .doOnCancel {
+                                            sendOneFrame(Frame.Cancel.from(streamId))
+                                        }
+                                        .doFinally {
+                                            removeReceiver(streamId)
+                                            removeSender(streamId)
+                                        }
+                            }
+                        }))
     }
 
     private operator fun contains(streamId: Int): Boolean {
-        synchronized(this@RSocketClient) {
+        synchronized(this) {
             return receivers.containsKey(streamId)
         }
     }
 
     protected fun cleanup() {
-        senders.forEach { integer, limitableRequestPublisher -> cleanUpLimitableRequestPublisher(limitableRequestPublisher) }
 
-        receivers.forEach { integer, subscriber -> cleanUpSubscriber(subscriber) }
+        var subscribers: Collection<Subscriber<Payload>>
+        var publishers: Collection<LimitableRequestPublisher<*>>
+        val (subs, pubs) = synchronized(this) {
 
-        synchronized(this) {
+            subscribers = receivers.values
+            publishers = senders.values
+
             senders.clear()
             receivers.clear()
+
+            Pair(subscribers,publishers)
         }
 
-        if (null != keepAliveSendSub) {
-            keepAliveSendSub!!.dispose()
-        }
+        subs.forEach { cleanUpSubscriber(it) }
+        pubs.forEach { cleanUpLimitableRequestPublisher(it) }
+
+        keepAliveSendSub?.dispose()
     }
 
     @Synchronized private fun cleanUpLimitableRequestPublisher(
-            limitableRequestPublisher: LimitedRequestPublisher<*>) {
-        limitableRequestPublisher.cancel()
+            limitableRequestPublisher: LimitableRequestPublisher<*>) {
+        try {
+            limitableRequestPublisher.cancel()
+        } catch (t: Throwable) {
+            errorConsumer(t)
+        }
+
     }
 
     @Synchronized private fun cleanUpSubscriber(subscriber: Subscriber<*>) {
-        subscriber.onError(CLOSED_CHANNEL_EXCEPTION)
+        try {
+            subscriber.onError(CLOSED_CHANNEL_EXCEPTION)
+        } catch (t: Throwable) {
+            errorConsumer(t)
+        }
+
     }
 
     private fun handleIncomingFrames(frame: Frame) {
@@ -310,45 +391,45 @@ internal class RSocketClient @JvmOverloads constructor(
     }
 
     private fun handleFrame(streamId: Int, type: FrameType, frame: Frame) {
-
-        var receiver = synchronized(this) {
-            receivers.get(streamId)
+        var receiver: Subscriber<Payload>? = null
+        synchronized(this) {
+            receiver = receivers.get(streamId)
         }
         if (receiver == null) {
             handleMissingResponseProcessor(streamId, type, frame)
         } else {
             when (type) {
                 FrameType.ERROR -> {
-                    receiver.onError(Exceptions.from(frame))
+                    receiver!!.onError(Exceptions.from(frame))
                     removeReceiver(streamId)
                 }
                 FrameType.NEXT_COMPLETE -> {
-                    receiver.onNext(PayloadImpl(frame))
-                    receiver.onComplete()
+                    receiver!!.onNext(PayloadImpl(frame))
+                    receiver!!.onComplete()
                 }
                 FrameType.CANCEL -> {
-
-                    var sender = synchronized(this) {
-                        val s = senders.remove(streamId)
+                    var sender: LimitableRequestPublisher<*>? = null
+                    synchronized(this) {
+                        sender = senders.remove(streamId)
                         removeReceiver(streamId)
-                        s
                     }
                     if (sender != null) {
-                        sender.cancel()
+                        sender!!.cancel()
                     }
                 }
-                FrameType.NEXT -> receiver.onNext(PayloadImpl(frame))
+                FrameType.NEXT -> receiver!!.onNext(PayloadImpl(frame))
                 FrameType.REQUEST_N -> {
-                    var sender = synchronized(this) {
-                        senders.get(streamId)
+                    var sender: LimitableRequestPublisher<*>? = null
+                    synchronized(this) {
+                        sender = senders.get(streamId)
                     }
                     if (sender != null) {
-                        val n = Frame.RequestN.requestN(frame)
-                        sender.increaseRequestLimit(n.toLong())
+                        val n = Frame.RequestN.requestN(frame).toLong()
+                        sender!!.increaseRequestLimit(n)
                     }
                 }
                 FrameType.COMPLETE -> {
-                    receiver.onComplete()
+                    receiver!!.onComplete()
                     synchronized(this) {
                         receivers.remove(streamId)
                     }
@@ -392,7 +473,7 @@ internal class RSocketClient @JvmOverloads constructor(
     }
 
     companion object {
-
         private val CLOSED_CHANNEL_EXCEPTION = noStacktrace(ClosedChannelException())
     }
+    private fun <T> UnicastProcessor<T>.isTerminated(): Boolean = hasComplete() || hasThrowable()
 }

--- a/rsocket-core/src/main/java/io/rsocket/internal/LimitableRequestPublisher.kt
+++ b/rsocket-core/src/main/java/io/rsocket/internal/LimitableRequestPublisher.kt
@@ -25,7 +25,7 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
 /**  */
-class LimitedRequestPublisher<T> private constructor(private val source: Publisher<T>) : Flowable<T>(), Subscription,Disposable {
+class LimitableRequestPublisher<T> private constructor(private val source: Publisher<T>) : Flowable<T>(), Subscription,Disposable {
 
     private val canceled: AtomicBoolean
 
@@ -97,13 +97,13 @@ class LimitedRequestPublisher<T> private constructor(private val source: Publish
     private inner class InnerSubscriber internal constructor(internal var destination: Subscriber<in T>) : Subscriber<T> {
 
         override fun onSubscribe(s: Subscription) {
-            synchronized(this@LimitedRequestPublisher) {
-                this@LimitedRequestPublisher.internalSubscription = s
+            synchronized(this@LimitableRequestPublisher) {
+                this@LimitableRequestPublisher.internalSubscription = s
 
                 if (canceled.get()) {
                     s.cancel()
                     subscribed = false
-                    this@LimitedRequestPublisher.internalSubscription = null
+                    this@LimitableRequestPublisher.internalSubscription = null
                 }
             }
 
@@ -130,7 +130,7 @@ class LimitedRequestPublisher<T> private constructor(private val source: Publish
 
     private inner class InnerSubscription : Subscription {
         override fun request(n: Long) {
-            synchronized(this@LimitedRequestPublisher) {
+            synchronized(this@LimitableRequestPublisher) {
                 internalRequested = BackpressureHelper.addCap(n, internalRequested)
             }
 
@@ -138,14 +138,14 @@ class LimitedRequestPublisher<T> private constructor(private val source: Publish
         }
 
         override fun cancel() {
-            this@LimitedRequestPublisher.cancel()
+            this@LimitableRequestPublisher.cancel()
         }
     }
 
     companion object {
 
-        fun <T> wrap(source: Publisher<T>): LimitedRequestPublisher<T> {
-            return LimitedRequestPublisher(source)
+        fun <T> wrap(source: Publisher<T>): LimitableRequestPublisher<T> {
+            return LimitableRequestPublisher(source)
         }
     }
 }

--- a/rsocket-server-netty/build.gradle
+++ b/rsocket-server-netty/build.gradle
@@ -15,6 +15,6 @@
  */
 
 dependencies {
-    compile 'io.rsocket:rsocket-core:0.9-SNAPSHOT'
+    compile 'io.rsocket:rsocket-core:0.9.16'
     compile 'io.rsocket:rsocket-transport-netty:0.9-SNAPSHOT'
 }

--- a/rsocket-server-netty/src/main/java/io/rsocket/transport/netty/sampleserver/Server.kt
+++ b/rsocket-server-netty/src/main/java/io/rsocket/transport/netty/sampleserver/Server.kt
@@ -4,29 +4,33 @@ import io.reactivex.Flowable
 import io.rsocket.*
 import io.rsocket.transport.netty.server.WebsocketServerTransport
 import io.rsocket.util.PayloadImpl
+import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.Duration
 import java.util.*
 
 fun main(args: Array<String>) {
+
     RSocketFactory.receive()
-            .acceptor (
-                object : SocketAcceptor {
-                    override fun accept(setup: ConnectionSetupPayload, sendingSocket: RSocket): Mono<RSocket> {
-                        return Mono.just(object : AbstractRSocket() {
-                            override fun requestResponse(payload: Payload): Mono<Payload> = Mono.just(PayloadImpl("reqrep pong!"))
+            .acceptor { _, sendingSocket ->
+                Mono.just(object : AbstractRSocket() {
+                    override fun requestResponse(payload: Payload): Mono<Payload> =
+                            Mono.just(PayloadImpl("reqrep pong!"))
 
-                            override fun requestStream(payload: Payload): Flux<Payload> {
-                                return Flux.interval(Duration.ZERO, Duration.ofSeconds(1)).take(5).map { v -> PayloadImpl("reqstream pong! $v") }
-                            }
+                    override fun requestStream(payload: Payload): Flux<Payload> =
+                            Flux.interval(Duration.ZERO, Duration.ofSeconds(1))
+                                    .take(5)
+                                    .map { v -> PayloadImpl("reqstream pong! $v") }
 
-                            override fun fireAndForget(payload: Payload?): Mono<Void> {
-                                return sendingSocket.fireAndForget(PayloadImpl("server fnf: ${Date()}"))
-                            }
-                        })
-                    }
-                }
-            ).transport(WebsocketServerTransport.create(8082)).start().block()
+                    override fun fireAndForget(payload: Payload?): Mono<Void> =
+                            sendingSocket.fireAndForget(PayloadImpl("server fnf: ${Date()}"))
+
+                    override fun requestChannel(payloads: Publisher<Payload>): Flux<Payload> =
+                            Flux.from(payloads)
+                                    .map { "server reqchannel: ${Date()}"}
+                                    .map { PayloadImpl(it) }
+                })
+            }.transport(WebsocketServerTransport.create(8082)).start().block()
     Flowable.never<Void>().blockingFirst()
 }


### PR DESCRIPTION
Closes  #4. For now `UnboundedProcessor` not implemented, substituted by `PublishProcessor`. Need to check whether still an issue for mobile use case. Verified with tests in #9 and sample mobile application