### PR TITLE
fix some classes having package io.rsocket instead of io.rsocket.android

### DIFF
--- a/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/RSocketPerf.java
@@ -17,7 +17,7 @@
 
 package io.rsocket;
 
-import io.rsocket.RSocketFactory.Start;
+import io.rsocket.android.RSocketFactory.Start;
 import io.rsocket.perfutil.TestDuplexConnection;
 import io.rsocket.android.PayloadImpl;
 import java.nio.ByteBuffer;

--- a/rsocket-core/src/jmh/java/io/rsocket/perfutil/TestDuplexConnection.java
+++ b/rsocket-core/src/jmh/java/io/rsocket/perfutil/TestDuplexConnection.java
@@ -17,8 +17,8 @@
 
 package io.rsocket.perfutil;
 
-import io.rsocket.DuplexConnection;
-import io.rsocket.Frame;
+import io.rsocket.android.DuplexConnection;
+import io.rsocket.android.Frame;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;

--- a/rsocket-core/src/main/java/io/rsocket/android/AbstractRSocket.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/AbstractRSocket.kt
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.reactivex.*
 import io.reactivex.processors.AsyncProcessor
-import io.reactivex.processors.PublishProcessor
-import org.intellij.lang.annotations.Flow
 import org.reactivestreams.Publisher
 
 /**

--- a/rsocket-core/src/main/java/io/rsocket/android/Availability.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/Availability.kt
@@ -11,7 +11,7 @@
  *  specific language governing permissions and limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 interface Availability {
 

--- a/rsocket-core/src/main/java/io/rsocket/android/Closeable.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/Closeable.kt
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.reactivex.Completable
 

--- a/rsocket-core/src/main/java/io/rsocket/android/ConnectionSetupPayload.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/ConnectionSetupPayload.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket
+package io.rsocket.android
 
 import io.rsocket.android.frame.FrameHeaderFlyweight.FLAGS_M
 

--- a/rsocket-core/src/main/java/io/rsocket/android/DuplexConnection.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/DuplexConnection.kt
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket
+package io.rsocket.android
 
 import io.reactivex.Completable
 import io.reactivex.Flowable
-import io.reactivex.Single
 import java.nio.channels.ClosedChannelException
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber

--- a/rsocket-core/src/main/java/io/rsocket/android/Duration.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/Duration.kt
@@ -1,4 +1,4 @@
-package io.rsocket
+package io.rsocket.android
 
 import java.util.concurrent.TimeUnit
 

--- a/rsocket-core/src/main/java/io/rsocket/android/Frame.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/Frame.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket
+package io.rsocket.android
 
 import io.rsocket.android.frame.FrameHeaderFlyweight.FLAGS_M
 
@@ -223,7 +223,7 @@ class Frame private constructor(private val handle: Handle<Frame>) : ByteBufHold
     }
 
     fun hasMetadata(): Boolean {
-        return Frame.isFlagSet(this.flags(), FLAGS_M)
+        return isFlagSet(this.flags(), FLAGS_M)
     }
 
     val dataUtf8: String

--- a/rsocket-core/src/main/java/io/rsocket/android/FrameType.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/FrameType.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket
+package io.rsocket.android
 
 /** Types of [Frame] that can be sent.  */
 enum class FrameType(val encodedType: Int, private val flags: Int = 0) {

--- a/rsocket-core/src/main/java/io/rsocket/android/Payload.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/Payload.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.rsocket
+package io.rsocket.android
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets

--- a/rsocket-core/src/main/java/io/rsocket/android/RSocket.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/RSocket.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.reactivex.Completable
 import io.reactivex.Flowable

--- a/rsocket-core/src/main/java/io/rsocket/android/RSocketClient.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/RSocketClient.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.rsocket.android.util.ExceptionUtil.noStacktrace
 

--- a/rsocket-core/src/main/java/io/rsocket/android/RSocketFactory.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/RSocketFactory.kt
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.reactivex.Completable
 import io.reactivex.Single
@@ -109,7 +109,7 @@ object RSocketFactory {
         fun metadataMimeType(metadataMimeType: String): T
     }
 
-    class ClientRSocketFactory : Acceptor<ClientTransportAcceptor, (RSocket)->  RSocket>,
+    class ClientRSocketFactory : Acceptor<ClientTransportAcceptor, (RSocket) -> RSocket>,
             ClientTransportAcceptor, KeepAlive<ClientRSocketFactory>,
             MimeType<ClientRSocketFactory>, Fragmentation<ClientRSocketFactory>,
             ErrorConsumer<ClientRSocketFactory>,
@@ -194,7 +194,7 @@ object RSocketFactory {
             return StartClient(transport)
         }
 
-        override fun acceptor(acceptor: () -> (RSocket) ->  RSocket): ClientTransportAcceptor {
+        override fun acceptor(acceptor: () -> (RSocket) -> RSocket): ClientTransportAcceptor {
             this.acceptor = acceptor
             return object : ClientTransportAcceptor {
                 override fun transport(transport: () -> ClientTransport): Start<RSocket> = StartClient(transport)

--- a/rsocket-core/src/main/java/io/rsocket/android/RSocketServer.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/RSocketServer.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.netty.buffer.Unpooled
 import io.netty.util.collection.IntObjectHashMap
@@ -25,7 +25,7 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.processors.FlowableProcessor
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.processors.UnicastProcessor
-import io.rsocket.Frame.Request.initialRequestN
+import io.rsocket.android.Frame.Request.initialRequestN
 import io.rsocket.android.exceptions.ApplicationException
 import io.rsocket.android.frame.FrameHeaderFlyweight.FLAGS_C
 import io.rsocket.android.frame.FrameHeaderFlyweight.FLAGS_M

--- a/rsocket-core/src/main/java/io/rsocket/android/SocketAcceptor.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/SocketAcceptor.kt
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 import io.reactivex.Single
 import io.rsocket.android.exceptions.SetupException

--- a/rsocket-core/src/main/java/io/rsocket/android/StreamIdSupplier.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/StreamIdSupplier.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.rsocket
+package io.rsocket.android
 
 internal class StreamIdSupplier private constructor(private var streamId: Int) {
 

--- a/rsocket-core/src/main/java/io/rsocket/android/exceptions/Exceptions.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/exceptions/Exceptions.kt
@@ -17,7 +17,7 @@ package io.rsocket.android.exceptions
 
 import io.rsocket.android.frame.ErrorFrameFlyweight.*
 
-import io.rsocket.Frame
+import io.rsocket.android.Frame
 
 object Exceptions {
 

--- a/rsocket-core/src/main/java/io/rsocket/android/fragmentation/FragmentationDuplexConnection.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/fragmentation/FragmentationDuplexConnection.kt
@@ -19,8 +19,8 @@ package io.rsocket.android.fragmentation
 import io.netty.util.collection.IntObjectHashMap
 import io.reactivex.Completable
 import io.reactivex.Flowable
-import io.rsocket.DuplexConnection
-import io.rsocket.Frame
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
 import io.rsocket.android.frame.FrameHeaderFlyweight
 import org.reactivestreams.Publisher
 

--- a/rsocket-core/src/main/java/io/rsocket/android/fragmentation/FrameFragmenter.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/fragmentation/FrameFragmenter.kt
@@ -20,8 +20,8 @@ import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.reactivex.Emitter
 import io.reactivex.Flowable
-import io.rsocket.Frame
-import io.rsocket.FrameType
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.frame.FrameHeaderFlyweight
 
 class FrameFragmenter(private val mtu: Int) {

--- a/rsocket-core/src/main/java/io/rsocket/android/fragmentation/FrameReassembler.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/fragmentation/FrameReassembler.kt
@@ -19,8 +19,8 @@ package io.rsocket.android.fragmentation
 import io.netty.buffer.CompositeByteBuf
 import io.netty.buffer.PooledByteBufAllocator
 import io.reactivex.disposables.Disposable
-import io.rsocket.Frame
-import io.rsocket.FrameType
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.frame.FrameHeaderFlyweight
 
 /** Assembles Fragmented frames.  */

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/ErrorFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/ErrorFrameFlyweight.java
@@ -16,7 +16,7 @@
 package io.rsocket.android.frame;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.FrameType;
+import io.rsocket.android.FrameType;
 import io.rsocket.android.exceptions.RSocketException;
 import java.nio.charset.StandardCharsets;
 

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/FrameHeaderFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/FrameHeaderFlyweight.java
@@ -19,8 +19,8 @@ import javax.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.rsocket.Frame;
-import io.rsocket.FrameType;
+import io.rsocket.android.Frame;
+import io.rsocket.android.FrameType;
 
 import static io.rsocket.android.frame.Utils.INTEGER_BYTES;
 import static io.rsocket.android.frame.Utils.SHORT_BYTES;

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/KeepaliveFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/KeepaliveFrameFlyweight.java
@@ -16,7 +16,7 @@
 package io.rsocket.android.frame;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.FrameType;
+import io.rsocket.android.FrameType;
 
 import static io.rsocket.android.frame.Utils.*;
 

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/LeaseFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/LeaseFrameFlyweight.java
@@ -16,7 +16,7 @@
 package io.rsocket.android.frame;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.FrameType;
+import io.rsocket.android.FrameType;
 
 import static io.rsocket.android.frame.Utils.*;
 

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/RequestFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/RequestFrameFlyweight.java
@@ -16,8 +16,8 @@
 package io.rsocket.android.frame;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.Frame;
-import io.rsocket.FrameType;
+import io.rsocket.android.Frame;
+import io.rsocket.android.FrameType;
 import javax.annotation.Nullable;
 
 import static io.rsocket.android.frame.Utils.INTEGER_BYTES;

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/RequestNFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/RequestNFrameFlyweight.java
@@ -16,7 +16,7 @@
 package io.rsocket.android.frame;
 
 import io.netty.buffer.ByteBuf;
-import io.rsocket.FrameType;
+import io.rsocket.android.FrameType;
 
 import static io.rsocket.android.frame.Utils.*;
 

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/SetupFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/SetupFrameFlyweight.java
@@ -21,7 +21,7 @@ import static io.rsocket.android.frame.Utils.SHORT_BYTES;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.rsocket.FrameType;
+import io.rsocket.android.FrameType;
 import java.nio.charset.StandardCharsets;
 
 public class SetupFrameFlyweight {

--- a/rsocket-core/src/main/java/io/rsocket/android/internal/ClientServerInputMultiplexer.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/internal/ClientServerInputMultiplexer.kt
@@ -19,9 +19,9 @@ package io.rsocket.android.internal
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.processors.BehaviorProcessor
-import io.rsocket.DuplexConnection
-import io.rsocket.Frame
-import io.rsocket.FrameType
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.plugins.DuplexConnectionInterceptor.Type
 import io.rsocket.android.plugins.PluginRegistry
 import org.reactivestreams.Publisher

--- a/rsocket-core/src/main/java/io/rsocket/android/plugins/DuplexConnectionInterceptor.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/plugins/DuplexConnectionInterceptor.kt
@@ -16,7 +16,7 @@
 
 package io.rsocket.android.plugins
 
-import io.rsocket.DuplexConnection
+import io.rsocket.android.DuplexConnection
 
 /**  */
 @FunctionalInterface

--- a/rsocket-core/src/main/java/io/rsocket/android/plugins/PluginRegistry.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/plugins/PluginRegistry.kt
@@ -16,8 +16,8 @@
 
 package io.rsocket.android.plugins
 
-import io.rsocket.DuplexConnection
-import io.rsocket.RSocket
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.RSocket
 import java.util.ArrayList
 
 class PluginRegistry {

--- a/rsocket-core/src/main/java/io/rsocket/android/plugins/RSocketInterceptor.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/plugins/RSocketInterceptor.kt
@@ -16,7 +16,7 @@
 
 package io.rsocket.android.plugins
 
-import io.rsocket.RSocket
+import io.rsocket.android.RSocket
 
 /**  */
 @FunctionalInterface

--- a/rsocket-core/src/main/java/io/rsocket/android/transport/ClientTransport.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/transport/ClientTransport.kt
@@ -17,7 +17,7 @@
 package io.rsocket.android.transport
 
 import io.reactivex.Single
-import io.rsocket.DuplexConnection
+import io.rsocket.android.DuplexConnection
 
 /** A client contract for writing transports of RSocket.  */
 interface ClientTransport : Transport {

--- a/rsocket-core/src/main/java/io/rsocket/android/transport/ServerTransport.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/transport/ServerTransport.kt
@@ -18,8 +18,8 @@ package io.rsocket.android.transport
 
 import io.reactivex.Completable
 import io.reactivex.Single
-import io.rsocket.Closeable
-import io.rsocket.DuplexConnection
+import io.rsocket.android.Closeable
+import io.rsocket.android.DuplexConnection
 
 /** A server contract for writing transports of RSocket.  */
 interface ServerTransport<T : Closeable> : Transport {

--- a/rsocket-core/src/main/java/io/rsocket/android/transport/TransportHeaderAware.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/transport/TransportHeaderAware.kt
@@ -1,7 +1,5 @@
 package io.rsocket.android.transport
 
-import java.util.function.Supplier
-
 /**
  * Extension interface to support Transports with headers at the transport layer, e.g. Websockets,
  * Http2.

--- a/rsocket-core/src/main/java/io/rsocket/android/util/CloseableAdapter.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/util/CloseableAdapter.kt
@@ -2,7 +2,7 @@ package io.rsocket.android.util
 
 import io.reactivex.Completable
 import io.reactivex.processors.AsyncProcessor
-import io.rsocket.Closeable
+import io.rsocket.android.Closeable
 
 class CloseableAdapter(private val closeFunction: () -> Unit) : Closeable {
     private val onClose = AsyncProcessor.create<Void>()

--- a/rsocket-core/src/main/java/io/rsocket/android/util/PayloadImpl.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/util/PayloadImpl.kt
@@ -16,8 +16,8 @@
 
 package io.rsocket.android.util
 
-import io.rsocket.Frame
-import io.rsocket.Payload
+import io.rsocket.android.Frame
+import io.rsocket.android.Payload
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets

--- a/rsocket-core/src/main/java/io/rsocket/android/util/RSocketProxy.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/util/RSocketProxy.kt
@@ -18,8 +18,8 @@ package io.rsocket.android.util
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Single
-import io.rsocket.Payload
-import io.rsocket.RSocket
+import io.rsocket.android.Payload
+import io.rsocket.android.RSocket
 import org.reactivestreams.Publisher
 
 /** Wrapper/Proxy for a RSocket. This is useful when we want to override a specific method.  */

--- a/rsocket-core/src/test/java/io/rsocket/android/FrameTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/FrameTest.kt
@@ -1,7 +1,5 @@
 package io.rsocket.android
 
-import io.rsocket.Frame
-import io.rsocket.FrameType
 import org.junit.Assert.assertEquals
 
 import io.rsocket.android.frame.FrameHeaderFlyweight

--- a/rsocket-core/src/test/java/io/rsocket/android/RSocketClientTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/RSocketClientTest.kt
@@ -20,7 +20,6 @@ package io.rsocket.android
 import io.reactivex.Completable
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.subscribers.TestSubscriber
-import io.rsocket.*
 import io.rsocket.android.exceptions.ApplicationException
 import io.rsocket.android.exceptions.RejectedSetupException
 import io.rsocket.android.frame.RequestFrameFlyweight

--- a/rsocket-core/src/test/java/io/rsocket/android/RSocketServerTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/RSocketServerTest.kt
@@ -23,7 +23,6 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.subscribers.TestSubscriber
-import io.rsocket.*
 import io.rsocket.android.test.util.LocalDuplexConnection
 import io.rsocket.android.util.PayloadImpl
 import org.hamcrest.MatcherAssert.assertThat

--- a/rsocket-core/src/test/java/io/rsocket/android/RSocketTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/RSocketTest.kt
@@ -21,7 +21,6 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.subscribers.TestSubscriber
-import io.rsocket.*
 import io.rsocket.android.test.util.LocalDuplexConnection
 import io.rsocket.android.util.PayloadImpl
 import org.hamcrest.MatcherAssert.assertThat

--- a/rsocket-core/src/test/java/io/rsocket/android/StreamIdSupplierTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/StreamIdSupplierTest.kt
@@ -16,7 +16,6 @@
 
 package io.rsocket.android
 
-import io.rsocket.StreamIdSupplier
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/rsocket-core/src/test/java/io/rsocket/android/fragmentation/FragmentationDuplexConnectionTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/fragmentation/FragmentationDuplexConnectionTest.kt
@@ -22,9 +22,9 @@ import io.reactivex.Flowable
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subscribers.TestSubscriber
-import io.rsocket.DuplexConnection
-import io.rsocket.Frame
-import io.rsocket.FrameType
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.util.PayloadImpl
 import org.junit.Assert
 import org.junit.Test

--- a/rsocket-core/src/test/java/io/rsocket/android/fragmentation/FrameFragmenterTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/fragmentation/FrameFragmenterTest.kt
@@ -17,9 +17,8 @@
 package io.rsocket.android.fragmentation
 
 import io.reactivex.subscribers.TestSubscriber
-import io.rsocket.Frame
-import io.rsocket.FrameType
-import io.rsocket.android.fragmentation.FrameFragmenter
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.util.PayloadImpl
 import org.junit.Test
 import java.nio.ByteBuffer

--- a/rsocket-core/src/test/java/io/rsocket/android/fragmentation/FrameReassemblerTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/fragmentation/FrameReassemblerTest.kt
@@ -16,10 +16,8 @@
 
 package io.rsocket.android.fragmentation
 
-import io.rsocket.Frame
-import io.rsocket.FrameType
-import io.rsocket.android.fragmentation.FrameFragmenter
-import io.rsocket.android.fragmentation.FrameReassembler
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.util.PayloadImpl
 import org.junit.Ignore
 import java.nio.ByteBuffer

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/ErrorFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/ErrorFrameFlyweightTest.kt
@@ -22,7 +22,7 @@ import org.junit.Assert.assertTrue
 
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.Frame
+import io.rsocket.android.Frame
 import io.rsocket.android.exceptions.*
 import java.nio.charset.StandardCharsets
 import org.junit.Test

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/FrameHeaderFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/FrameHeaderFlyweightTest.kt
@@ -22,7 +22,7 @@ import org.junit.Assert.*
 
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.FrameType
+import io.rsocket.android.FrameType
 import org.junit.Test
 
 class FrameHeaderFlyweightTest {

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/KeepaliveFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/KeepaliveFrameFlyweightTest.kt
@@ -16,14 +16,11 @@
 
 package io.rsocket.android.frame
 
-import org.junit.Assert.*
-
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.android.frame.FrameHeaderFlyweight
-import io.rsocket.android.frame.KeepaliveFrameFlyweight
-import java.nio.charset.StandardCharsets
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.nio.charset.StandardCharsets
 
 class KeepaliveFrameFlyweightTest {
     private val byteBuf = Unpooled.buffer(1024)

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/LeaseFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/LeaseFrameFlyweightTest.kt
@@ -16,13 +16,11 @@
 
 package io.rsocket.android.frame
 
-import org.junit.Assert.*
-
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.android.frame.LeaseFrameFlyweight
-import java.nio.charset.StandardCharsets
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.nio.charset.StandardCharsets
 
 class LeaseFrameFlyweightTest {
     private val byteBuf = Unpooled.buffer(1024)

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/RequestFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/RequestFrameFlyweightTest.kt
@@ -22,10 +22,8 @@ import org.junit.Assert.assertFalse
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.Frame
-import io.rsocket.FrameType
-import io.rsocket.android.frame.FrameHeaderFlyweight
-import io.rsocket.android.frame.RequestFrameFlyweight
+import io.rsocket.android.Frame
+import io.rsocket.android.FrameType
 import io.rsocket.android.util.PayloadImpl
 import java.nio.charset.StandardCharsets
 import org.junit.Test

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/RequestNFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/RequestNFrameFlyweightTest.kt
@@ -16,11 +16,9 @@
 
 package io.rsocket.android.frame
 
-import org.junit.Assert.assertEquals
-
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.android.frame.RequestNFrameFlyweight
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RequestNFrameFlyweightTest {

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/SetupFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/SetupFrameFlyweightTest.kt
@@ -20,9 +20,7 @@ import org.junit.Assert.*
 
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.rsocket.FrameType
-import io.rsocket.android.frame.FrameHeaderFlyweight
-import io.rsocket.android.frame.SetupFrameFlyweight
+import io.rsocket.android.FrameType
 import java.nio.charset.StandardCharsets
 import org.junit.Test
 

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/VersionFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/VersionFlyweightTest.kt
@@ -16,9 +16,7 @@
 
 package io.rsocket.android.frame
 
-import io.rsocket.android.frame.VersionFlyweight
-import org.junit.Assert.*
-
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class VersionFlyweightTest {

--- a/rsocket-core/src/test/java/io/rsocket/android/internal/ClientServerInputMultiplexerTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/internal/ClientServerInputMultiplexerTest.kt
@@ -19,7 +19,7 @@ package io.rsocket.android.internal
 
 import org.junit.Assert.assertEquals
 
-import io.rsocket.Frame
+import io.rsocket.android.Frame
 import io.rsocket.android.plugins.PluginRegistry
 import io.rsocket.android.test.util.TestDuplexConnection
 import java.util.concurrent.atomic.AtomicInteger

--- a/rsocket-core/src/test/java/io/rsocket/android/test/util/LocalDuplexConnection.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/test/util/LocalDuplexConnection.kt
@@ -21,9 +21,8 @@ import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.processors.FlowableProcessor
 import io.reactivex.processors.PublishProcessor
-import io.rsocket.Availability
-import io.rsocket.DuplexConnection
-import io.rsocket.Frame
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
 import org.reactivestreams.Publisher
 
 class LocalDuplexConnection(

--- a/rsocket-core/src/test/java/io/rsocket/android/test/util/MockRSocket.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/test/util/MockRSocket.kt
@@ -23,8 +23,8 @@ import io.reactivex.Single
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 
-import io.rsocket.Payload
-import io.rsocket.RSocket
+import io.rsocket.android.Payload
+import io.rsocket.android.RSocket
 import java.util.concurrent.atomic.AtomicInteger
 import org.reactivestreams.Publisher
 

--- a/rsocket-core/src/test/java/io/rsocket/android/test/util/TestDuplexConnection.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/test/util/TestDuplexConnection.kt
@@ -20,8 +20,8 @@ package io.rsocket.android.test.util
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.processors.PublishProcessor
-import io.rsocket.DuplexConnection
-import io.rsocket.Frame
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.LinkedBlockingQueue
 import org.reactivestreams.Publisher

--- a/rsocket-core/src/test/java/io/rsocket/android/test/util/TestSubscriber.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/test/util/TestSubscriber.kt
@@ -3,7 +3,7 @@ package io.rsocket.android.test.util
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 
-import io.rsocket.Payload
+import io.rsocket.android.Payload
 import org.mockito.Mockito
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription

--- a/rsocket-core/src/test/java/io/rsocket/android/util/PayloadImplTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/util/PayloadImplTest.kt
@@ -16,7 +16,7 @@ package io.rsocket.android.util
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 
-import io.rsocket.Payload
+import io.rsocket.android.Payload
 import io.rsocket.android.util.PayloadImpl.Companion.textPayload
 import org.junit.Test
 

--- a/rsocket-test/build.gradle
+++ b/rsocket-test/build.gradle
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-    compile project(':rsocket-core')
+    compile project(':rsocket-android-core')
     compile "junit:junit:4.12"
     compile "org.mockito:mockito-core:2.10.0"
     compile "org.hamcrest:hamcrest-library:1.3"

--- a/rsocket-test/src/main/java/io/rsocket/test/BaseClientServerTest.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/BaseClientServerTest.java
@@ -19,7 +19,7 @@
 
    import static org.junit.Assert.assertEquals;
 
-   import io.rsocket.Payload;
+   import io.rsocket.android.Payload;
    import io.rsocket.util.PayloadImpl;
    import org.junit.Ignore;
    import org.junit.Rule;

--- a/rsocket-test/src/main/java/io/rsocket/test/ClientSetupRule.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/ClientSetupRule.java
@@ -17,9 +17,9 @@
 
    package io.rsocket.test;
 
-   import io.rsocket.Closeable;
-   import io.rsocket.RSocket;
-   import io.rsocket.RSocketFactory;
+   import io.rsocket.android.Closeable;
+   import io.rsocket.android.RSocket;
+   import io.rsocket.android.RSocketFactory;
    import io.rsocket.transport.ClientTransport;
    import io.rsocket.transport.ServerTransport;
    import java.util.function.BiFunction;

--- a/rsocket-test/src/main/java/io/rsocket/test/CountdownBaseSubscriber.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/CountdownBaseSubscriber.java
@@ -1,7 +1,7 @@
 /*
 package io.rsocket.test;
 
-import io.rsocket.Payload;
+import io.rsocket.android.Payload;
 import java.util.concurrent.CountDownLatch;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.BaseSubscriber;

--- a/rsocket-test/src/main/java/io/rsocket/test/PingClient.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/PingClient.java
@@ -17,8 +17,8 @@
 
    package io.rsocket.test;
 
-   import io.rsocket.Payload;
-   import io.rsocket.RSocket;
+   import io.rsocket.android.Payload;
+   import io.rsocket.android.RSocket;
    import io.rsocket.util.PayloadImpl;
    import java.time.Duration;
    import org.HdrHistogram.Recorder;

--- a/rsocket-test/src/main/java/io/rsocket/test/PingHandler.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/PingHandler.java
@@ -17,11 +17,11 @@
 
    package io.rsocket.test;
 
-   import io.rsocket.AbstractRSocket;
-   import io.rsocket.ConnectionSetupPayload;
-   import io.rsocket.Payload;
-   import io.rsocket.RSocket;
-   import io.rsocket.SocketAcceptor;
+   import io.rsocket.android.AbstractRSocket;
+   import io.rsocket.android.ConnectionSetupPayload;
+   import io.rsocket.android.Payload;
+   import io.rsocket.android.RSocket;
+   import io.rsocket.android.SocketAcceptor;
    import io.rsocket.util.PayloadImpl;
    import java.util.concurrent.ThreadLocalRandom;
    import reactor.core.publisher.Mono;

--- a/rsocket-test/src/main/java/io/rsocket/test/TestRSocket.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TestRSocket.java
@@ -17,8 +17,8 @@
 
    package io.rsocket.test;
 
-   import io.rsocket.AbstractRSocket;
-   import io.rsocket.Payload;
+   import io.rsocket.android.AbstractRSocket;
+   import io.rsocket.android.Payload;
    import io.rsocket.util.PayloadImpl;
    import org.reactivestreams.Publisher;
    import reactor.core.publisher.Flux;

--- a/rsocket-test/src/main/java/io/rsocket/test/TestSubscriber.java
+++ b/rsocket-test/src/main/java/io/rsocket/test/TestSubscriber.java
@@ -4,7 +4,7 @@ package io.rsocket.test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
-import io.rsocket.Payload;
+import io.rsocket.android.Payload;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;

--- a/rsocket-transport-okhttp/src/main/java/io/rsocket/transport/okhttp/OkhttpWebsocketConnection.kt
+++ b/rsocket-transport-okhttp/src/main/java/io/rsocket/transport/okhttp/OkhttpWebsocketConnection.kt
@@ -7,8 +7,8 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.processors.BehaviorProcessor
 import io.reactivex.processors.UnicastProcessor
-import io.rsocket.DuplexConnection
-import io.rsocket.Frame
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
 import io.rsocket.android.frame.FrameHeaderFlyweight.FRAME_LENGTH_SIZE
 import io.rsocket.android.frame.FrameHeaderFlyweight.encodeLength
 import okhttp3.*

--- a/rsocket-transport-okhttp/src/main/java/io/rsocket/transport/okhttp/client/OkhttpWebsocketClientTransport.kt
+++ b/rsocket-transport-okhttp/src/main/java/io/rsocket/transport/okhttp/client/OkhttpWebsocketClientTransport.kt
@@ -2,7 +2,7 @@ package io.rsocket.transport.okhttp.client
 
 import io.rsocket.transport.okhttp.OkWebsocket
 import io.reactivex.Single
-import io.rsocket.DuplexConnection
+import io.rsocket.android.DuplexConnection
 import io.rsocket.android.transport.ClientTransport
 
 /**


### PR DESCRIPTION
In #11 some classes had filesystem path updated to io/rsocket/android, but package still was io.rsocket.