### PR TITLE
Netty client & server transports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,15 @@
 
 plugins {
     id "com.gradle.build-scan" version "1.12.1"
-    id 'com.jfrog.bintray' version '1.7.3'
-    id 'com.jfrog.artifactory' version '4.7.1'
-    id "org.jetbrains.kotlin.jvm" version "1.2.41"
+    id 'com.jfrog.bintray' version '1.7.3' apply false
+    id 'com.jfrog.artifactory' version '4.7.1' apply false
+    id "org.jetbrains.kotlin.jvm" version "1.2.41" apply false
 }
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'kotlin'
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'com.jfrog.artifactory'
@@ -54,17 +54,17 @@ subprojects {
     }
 
     dependencies {
-        compile "io.netty:netty-buffer:4.1.24.Final"
-        compile "org.reactivestreams:reactive-streams:1.0.2"
-        compile "org.slf4j:slf4j-api:1.7.25"
-        compile "com.google.code.findbugs:jsr305:3.0.2"
-        compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.41"
-        compile 'io.reactivex.rxjava2:rxjava:2.1.13'
+        api "io.netty:netty-buffer:4.1.24.Final"
+        api "org.reactivestreams:reactive-streams:1.0.2"
+        api "com.google.code.findbugs:jsr305:3.0.2"
+        api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41"
+        api 'io.reactivex.rxjava2:rxjava:2.1.13'
+        api "org.slf4j:slf4j-api:1.7.25"
 
-        testCompile "junit:junit:4.12"
-        testCompile "org.mockito:mockito-core:2.18.3"
-        testCompile "org.hamcrest:hamcrest-library:1.3"
-        testCompile "org.slf4j:slf4j-log4j12:1.7.25"
+        testImplementation "junit:junit:4.12"
+        testImplementation "org.mockito:mockito-core:2.18.3"
+        testImplementation "org.hamcrest:hamcrest-library:1.3"
+        testImplementation "org.slf4j:slf4j-log4j12:1.7.25"
     }
 
     publishing {

--- a/rsocket-core/src/main/java/io/rsocket/android/ConnectionSetupPayload.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/ConnectionSetupPayload.kt
@@ -33,8 +33,6 @@ abstract class ConnectionSetupPayload : Payload {
 
     fun willClientHonorLease(): Boolean = Frame.isFlagSet(flags, HONOR_LEASE)
 
-    fun doesClientRequestStrictInterpretation(): Boolean = STRICT_INTERPRETATION == flags and STRICT_INTERPRETATION
-
     override fun hasMetadata(): Boolean = Frame.isFlagSet(flags, FLAGS_M)
 
     private class ConnectionSetupPayloadImpl(
@@ -59,7 +57,6 @@ abstract class ConnectionSetupPayload : Payload {
 
         private val NO_FLAGS = 0
         val HONOR_LEASE = SetupFrameFlyweight.FLAGS_WILL_HONOR_LEASE
-        val STRICT_INTERPRETATION = SetupFrameFlyweight.FLAGS_STRICT_INTERPRETATION
 
         fun create(metadataMimeType: String, dataMimeType: String): ConnectionSetupPayload {
             return ConnectionSetupPayloadImpl(

--- a/rsocket-core/src/main/java/io/rsocket/android/Frame.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/Frame.kt
@@ -236,10 +236,7 @@ class Frame private constructor(private val handle: Handle<Frame>) : ByteBufHold
                 Unpooled.wrappedBuffer(payload.metadata)
             else
                 Unpooled.EMPTY_BUFFER
-            val data = if (payload.data != null)
-                Unpooled.wrappedBuffer(payload.data)
-            else
-                Unpooled.EMPTY_BUFFER
+            val data = Unpooled.wrappedBuffer(payload.data)
 
             val frame = RECYCLER.get()
             frame.content = ByteBufAllocator.DEFAULT.buffer(

--- a/rsocket-core/src/main/java/io/rsocket/android/RSocketClient.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/RSocketClient.kt
@@ -17,7 +17,6 @@
 package io.rsocket.android
 
 import io.netty.buffer.Unpooled
-import io.netty.util.collection.IntObjectHashMap
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Single
@@ -32,11 +31,13 @@ import io.rsocket.android.util.ExceptionUtil.noStacktrace
 import io.rsocket.android.util.PayloadImpl
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import java.nio.channels.ClosedChannelException
 import java.util.concurrent.CancellationException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /** Client Side of a RSocket socket. Sends [Frame]s to a [RSocketServer]  */
 internal class RSocketClient @JvmOverloads constructor(
@@ -48,30 +49,12 @@ internal class RSocketClient @JvmOverloads constructor(
         ackTimeout: Duration = Duration.ZERO,
         missedAcks: Int = 0) : RSocket {
 
-    internal constructor(connection: DuplexConnection,
-                         errorConsumer: (Throwable) -> Unit,
-                         streamIdSupplier: StreamIdSupplier,
-                         tickPeriod: Duration = Duration.ZERO,
-                         ackTimeout: Duration = Duration.ZERO,
-                         missedAcks: Int = 0)
-            : this(
-            connection,
-            errorConsumer,
-            streamIdSupplier,
-            DEFAULT_STREAM_WINDOW,
-            tickPeriod,
-            ackTimeout,
-            missedAcks)
-
-    private val started: PublishProcessor<Void> = PublishProcessor.create()
-    private val completeOnStart = started.ignoreElements()
-    private val senders: IntObjectHashMap<LimitableRequestPublisher<*>> = IntObjectHashMap(256, 0.9f)
-    private val receivers: IntObjectHashMap<Subscriber<Payload>> = IntObjectHashMap(256, 0.9f)
+    private val senders = ConcurrentHashMap<Int, Subscription>(256)
+    private val receivers = ConcurrentHashMap<Int, Subscriber<Payload>>(256)
     private val missedAckCounter: AtomicInteger = AtomicInteger()
-    @Volatile
-    private var errorSignal: Throwable? = null
+    private val interactions = Interactions()
 
-    private val sendProcessor: FlowableProcessor<Frame> = PublishProcessor
+    private val sentFrames: FlowableProcessor<Frame> = UnicastProcessor
             .create<Frame>()
             .toSerialized()
 
@@ -80,40 +63,180 @@ internal class RSocketClient @JvmOverloads constructor(
     private var timeLastTickSentMs: Long = 0
 
     init {
-        // DO NOT Change the order here. The Send processor must be subscribed to before receiving
-        if (Duration.ZERO != tickPeriod) {
-            val ackTimeoutMs = ackTimeout.toMillis
-
-            this.keepAliveSendSub = completeOnStart
-                    .andThen(Flowable.interval(tickPeriod.toMillis, TimeUnit.MILLISECONDS))
-                    .doOnSubscribe { _ -> timeLastTickSentMs = System.currentTimeMillis() }
-                    .concatMap { _ -> sendKeepAlive(ackTimeoutMs, missedAcks).toFlowable<Long>() }
-                    .subscribe({},
-                            { t: Throwable ->
-                                errorConsumer(t)
-                                connection.close().subscribe({}, errorConsumer)
-                            })
-        }
-
         connection
-                .onClose()
-                .doFinally { cleanup() }
-                .subscribe({}, errorConsumer)
-
-        connection
-                .send(sendProcessor)
-                .subscribe({}, { handleSendProcessorError(it) })
-
+                .send(sentFrames)
+                .subscribe(
+                        {},
+                        { interactions.error(it) })
         connection
                 .receive()
-                .doOnSubscribe { started.onComplete() }
-                .subscribe({ handleIncomingFrames(it) }, errorConsumer)
+                .subscribe(
+                        { handleFrame(it) },
+                        { interactions.error(it) })
+        connection
+                .onClose()
+                .subscribe(
+                        { interactions.complete() },
+                        errorConsumer)
+
+        if (Duration.ZERO != tickPeriod) {
+            val ackTimeoutMs = ackTimeout.toMillis
+            this.keepAliveSendSub =
+                    Flowable.interval(tickPeriod.toMillis, TimeUnit.MILLISECONDS)
+                            .doOnSubscribe { _ -> timeLastTickSentMs = System.currentTimeMillis() }
+                            .concatMap { _ -> sendKeepAlive(ackTimeoutMs, missedAcks).toFlowable<Long>() }
+                            .subscribe({},
+                                    { t: Throwable ->
+                                        errorConsumer(t)
+                                        connection.close().subscribe({}, errorConsumer)
+                                    })
+        }
     }
 
-    private fun handleSendProcessorError(t: Throwable) {
-        synchronized(this) {
-            receivers.values.forEach { it.onError(t) }
-            senders.values.forEach { it.cancel() }
+    override fun fireAndForget(payload: Payload): Completable =
+            interactions.fireAndForget(doHandleFireAndForget(payload))
+
+    override fun requestResponse(payload: Payload): Single<Payload> =
+            interactions.requestResponse(doHandleRequestResponse(payload))
+
+    override fun requestStream(payload: Payload): Flowable<Payload> =
+            interactions.requestStream(
+                    doHandleRequestStream(payload).rebatchRequests(streamDemandLimit))
+
+    override fun requestChannel(payloads: Publisher<Payload>): Flowable<Payload> =
+            interactions.requestChannel(
+                    doHandleChannel(
+                            Flowable.fromPublisher(payloads)
+                                    .rebatchRequests(streamDemandLimit)
+                    ).rebatchRequests(streamDemandLimit))
+
+    override fun metadataPush(payload: Payload): Completable =
+            interactions.metadataPush(doMetadataPush(payload))
+
+    override fun availability(): Double = connection.availability()
+
+    override fun close(): Completable = connection.close()
+
+    override fun onClose(): Completable = connection.onClose()
+
+    private fun doHandleFireAndForget(payload: Payload): Completable {
+        return Completable.fromRunnable {
+            val streamId = streamIdSupplier.nextStreamId()
+            val requestFrame = Frame.Request.from(
+                    streamId,
+                    FrameType.FIRE_AND_FORGET,
+                    payload,
+                    1)
+            sentFrames.onNext(requestFrame)
+        }
+    }
+
+    private fun doHandleRequestResponse(payload: Payload): Single<Payload> {
+        return Single.defer {
+            val streamId = streamIdSupplier.nextStreamId()
+            val requestFrame = Frame.Request.from(
+                    streamId, FrameType.REQUEST_RESPONSE, payload, 1)
+
+            val receiver = PublishProcessor.create<Payload>()
+            receivers[streamId] = receiver
+            sentFrames.onNext(requestFrame)
+
+            receiver
+                    .doOnCancel { sentFrames.onNext(Frame.Cancel.from(streamId)) }
+                    .doFinally { receivers -= streamId }
+                    .firstOrError()
+        }
+    }
+
+    private fun doHandleRequestStream(payload: Payload): Flowable<Payload> {
+        return Flowable.defer {
+            val streamId = streamIdSupplier.nextStreamId()
+            val receiver = UnicastProcessor.create<Payload>()
+            receivers[streamId] = receiver
+            var firstRequest = true
+
+            receiver.doOnRequest { requestN ->
+                if (!receiver.isTerminated()) {
+                    val first = firstRequest
+                    firstRequest = false
+                    val frame = if (first)
+                        Frame.Request.from(streamId, FrameType.REQUEST_STREAM, payload, requestN)
+                    else
+                        Frame.RequestN.from(streamId, requestN)
+                    sentFrames.onNext(frame)
+                }
+            }.doOnCancel {
+                sentFrames.onNext(Frame.Cancel.from(streamId))
+            }.doFinally {
+                receivers -= streamId
+            }
+        }
+    }
+
+    private fun doHandleChannel(request: Flowable<Payload>): Flowable<Payload> {
+        return Flowable.defer {
+            val receiver = UnicastProcessor.create<Payload>()
+            val streamId = streamIdSupplier.nextStreamId()
+            var firstRequest = true
+
+            receiver.doOnRequest { requestN ->
+                if (!receiver.isTerminated()) {
+                    val firstReq = firstRequest
+                    firstRequest = false
+                    if (firstReq) {
+                        var firstPayload = true
+                        request.compose { req ->
+                            val sender = LimitableRequestPublisher.wrap(req)
+                            sender.increaseRequestLimit(1)
+                            senders[streamId] = sender
+                            receivers[streamId] = receiver
+                            sender
+                        }.map { payload ->
+                            val first = firstPayload
+                            firstPayload = false
+                            val frame: Frame =
+                                    if (first) {
+                                        Frame.Request.from(
+                                                streamId, FrameType.REQUEST_CHANNEL, payload, requestN)
+                                    } else {
+                                        Frame.PayloadFrame.from(
+                                                streamId, FrameType.NEXT, payload)
+                                    }
+                            frame
+                        }.subscribe(
+                                { sentFrames.onNext(it) },
+                                { receiver.onError(CancellationException("Disposed")) },
+                                {
+                                    if (firstPayload) {
+                                        receiver.onComplete()
+                                    } else {
+                                        sentFrames.onNext(Frame.PayloadFrame.from(
+                                                streamId, FrameType.COMPLETE))
+                                    }
+                                })
+                    } else {
+                        sentFrames.onNext(Frame.RequestN.from(streamId, requestN))
+                    }
+                }
+            }.doOnError { t ->
+                sentFrames.onNext(Frame.Error.from(streamId, t))
+            }.doOnCancel {
+                sentFrames.onNext(Frame.Cancel.from(streamId))
+            }.doFinally {
+                receivers -= streamId
+                senders.remove(streamId)?.cancel()
+            }
+        }
+    }
+
+    private fun doMetadataPush(payload: Payload): Completable {
+        return Completable.fromRunnable {
+            val requestFrame = Frame.Request.from(
+                    0,
+                    FrameType.METADATA_PUSH,
+                    payload,
+                    1)
+            sentFrames.onNext(requestFrame)
         }
     }
 
@@ -129,264 +252,25 @@ internal class RSocketClient @JvmOverloads constructor(
                     throw ConnectionException(message)
                 }
             }
-
-            sendProcessor.onNext(Frame.Keepalive.from(Unpooled.EMPTY_BUFFER, true))
+            sentFrames.onNext(
+                    Frame.Keepalive.from(Unpooled.EMPTY_BUFFER, true))
         }
     }
 
-    override fun fireAndForget(payload: Payload): Completable {
-        val defer = Completable.fromRunnable {
-            val streamId = streamIdSupplier.nextStreamId()
-            val requestFrame = Frame.Request.from(
-                    streamId,
-                    FrameType.FIRE_AND_FORGET,
-                    payload,
-                    1)
-            sendProcessor.onNext(requestFrame)
-        }
-
-        return errorSignal
-                ?.let { Completable.error(it) }
-                ?: completeOnStart.andThen(defer)
-    }
-
-    override fun requestResponse(payload: Payload): Single<Payload> =
-            errorSignal
-                    ?.let { Single.error<Payload>(it) }
-                    ?: handleRequestResponse(payload)
-
-    override fun requestStream(payload: Payload): Flowable<Payload> =
-            errorSignal
-                    ?.let { Flowable.error<Payload>(it) }
-                    ?: handleRequestStream(payload).rebatchRequests(streamDemandLimit)
-
-    override fun requestChannel(payloads: Publisher<Payload>): Flowable<Payload> =
-            errorSignal
-                    ?.let { Flowable.error<Payload>(it) }
-                    ?: handleChannel(
-                    Flowable.fromPublisher(payloads).rebatchRequests(streamDemandLimit),
-                    FrameType.REQUEST_CHANNEL
-            ).rebatchRequests(streamDemandLimit)
-
-    override fun metadataPush(payload: Payload): Completable =
-            errorSignal
-                    ?.let { Completable.error(it) }
-                    ?: handleMetadataPush(payload)
-
-    override fun availability(): Double = connection.availability()
-
-    override fun close(): Completable = connection.close()
-
-    override fun onClose(): Completable = connection.onClose()
-
-    private fun handleMetadataPush(payload: Payload): Completable {
-        val requestFrame = Frame.Request.from(
-                0,
-                FrameType.METADATA_PUSH,
-                payload,
-                1)
-        sendProcessor.onNext(requestFrame)
-        return Completable.complete()
-    }
-
-    private fun handleRequestStream(payload: Payload): Flowable<Payload> {
-        return completeOnStart.andThen(
-                Flowable.defer {
-                    val streamId = streamIdSupplier.nextStreamId()
-                    val receiver = UnicastProcessor.create<Payload>()
-                    synchronized(this) {
-                        receivers.put(streamId, receiver)
-                    }
-
-                    val first = AtomicBoolean(false)
-
-                    receiver
-                            .doOnRequest { l ->
-                                if (first.compareAndSet(false, true) && !receiver.isTerminated()) {
-                                    val requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_STREAM, payload, l)
-                                    sendProcessor.onNext(requestFrame)
-                                } else if (contains(streamId)) {
-                                    sendProcessor.onNext(Frame.RequestN.from(streamId, l))
-                                }
-                            }
-                            .doOnError { t ->
-                                if (contains(streamId) && !receiver.isTerminated()) {
-                                    sendProcessor.onNext(Frame.Error.from(streamId, t))
-                                }
-                            }
-                            .doOnCancel {
-                                if (contains(streamId) && !receiver.isTerminated()) {
-                                    sendProcessor.onNext(Frame.Cancel.from(streamId))
-                                }
-                            }
-                            .doFinally { removeReceiver(streamId) }
-                })
-    }
-
-    private fun handleRequestResponse(payload: Payload): Single<Payload> {
-        return completeOnStart.andThen(
-                Single.defer(
-                        {
-                            val streamId = streamIdSupplier.nextStreamId()
-                            val requestFrame = Frame.Request.from(streamId, FrameType.REQUEST_RESPONSE, payload, 1)
-
-                            val receiver = PublishProcessor.create<Payload>()
-
-                            synchronized(this) {
-                                receivers.put(streamId, receiver)
-                            }
-
-                            sendProcessor.onNext(requestFrame)
-
-                            receiver
-                                    .doOnError { t -> sendProcessor.onNext(Frame.Error.from(streamId, t)) }
-                                    .doOnCancel { sendProcessor.onNext(Frame.Cancel.from(streamId)) }
-                                    .doFinally { removeReceiver(streamId) }
-                                    .firstOrError()
-                        }))
-    }
-
-    private fun handleChannel(request: Flowable<Payload>, requestType: FrameType): Flowable<Payload> {
-        return completeOnStart.andThen(
-                Flowable.defer(
-                        object : () -> Flowable<Payload> {
-                            internal val receiver = UnicastProcessor.create<Payload>()
-                            internal val streamId = streamIdSupplier.nextStreamId()
-                            internal var firstRequest = true
-
-                            internal val isValidToSendFrame: Boolean
-                                get() = contains(streamId) && !receiver.isTerminated()
-
-                            internal fun sendOneFrame(frame: Frame) {
-                                if (isValidToSendFrame) {
-                                    sendProcessor.onNext(frame)
-                                }
-                            }
-
-                            override fun invoke(): Flowable<Payload> {
-                                return receiver
-                                        .doOnRequest(
-                                                { l ->
-                                                    var _firstRequest = false
-                                                    synchronized(this) {
-                                                        if (firstRequest) {
-                                                            _firstRequest = true
-                                                            firstRequest = false
-                                                        }
-                                                    }
-
-                                                    if (_firstRequest) {
-                                                        val firstPayload = AtomicBoolean(true)
-                                                        val requestFrames = request
-                                                                .compose { f ->
-                                                                    val wrapped = LimitableRequestPublisher.wrap(f)
-                                                                    // Need to set this to one for first the frame
-                                                                    wrapped.increaseRequestLimit(1)
-                                                                    synchronized(this) {
-                                                                        senders.put(streamId, wrapped)
-                                                                        receivers.put(streamId, receiver)
-                                                                    }
-                                                                    wrapped
-                                                                }
-                                                                .map { payload ->
-                                                                    val requestFrame: Frame =
-                                                                            if (firstPayload.compareAndSet(true, false)) {
-                                                                                Frame.Request.from(
-                                                                                        streamId, requestType, payload, l)
-                                                                            } else {
-                                                                                Frame.PayloadFrame.from(
-                                                                                        streamId, FrameType.NEXT, payload)
-                                                                            }
-                                                                    requestFrame
-                                                                }
-                                                                .doOnComplete {
-                                                                    if (FrameType.REQUEST_CHANNEL === requestType) {
-                                                                        sendOneFrame(
-                                                                                Frame.PayloadFrame.from(
-                                                                                        streamId, FrameType.COMPLETE))
-                                                                        if (firstPayload.get()) {
-                                                                            receiver.onComplete()
-                                                                        }
-                                                                    }
-                                                                }
-
-                                                        requestFrames
-                                                                .doOnNext { sendProcessor.onNext(it) }
-                                                                .subscribe(
-                                                                        {},
-                                                                        { t ->
-                                                                            errorConsumer(t)
-                                                                            receiver.onError(CancellationException("Disposed"))
-                                                                        })
-                                                    } else {
-                                                        sendOneFrame(Frame.RequestN.from(streamId, l))
-                                                    }
-                                                })
-                                        .doOnError { t -> sendOneFrame(Frame.Error.from(streamId, t)) }
-                                        .doOnCancel {
-                                            sendOneFrame(Frame.Cancel.from(streamId))
-                                        }
-                                        .doFinally {
-                                            removeReceiver(streamId)
-                                            removeSender(streamId)
-                                        }
-                            }
-                        }))
-    }
-
-    private operator fun contains(streamId: Int): Boolean {
-        synchronized(this) {
-            return receivers.containsKey(streamId)
-        }
-    }
-
-    private fun cleanup() {
-        errorSignal = CLOSED_CHANNEL_EXCEPTION
-
-        synchronized(this) {
-            receivers.values.forEach { cleanUpSubscriber(it) }
-            senders.values.forEach { cleanUpLimitableRequestPublisher(it) }
-
-            receivers.clear()
-            senders.clear()
-        }
-        keepAliveSendSub?.dispose()
-    }
-
-    @Synchronized
-    private fun cleanUpLimitableRequestPublisher(
-            limitableRequestPublisher: LimitableRequestPublisher<*>) {
-        try {
-            limitableRequestPublisher.cancel()
-        } catch (t: Throwable) {
-            errorConsumer(t)
-        }
-    }
-
-    @Synchronized
-    private fun cleanUpSubscriber(subscriber: Subscriber<*>) {
-        try {
-            subscriber.onError(CLOSED_CHANNEL_EXCEPTION)
-        } catch (t: Throwable) {
-            errorConsumer(t)
-        }
-    }
-
-    private fun handleIncomingFrames(frame: Frame) {
+    private fun handleFrame(frame: Frame) {
         try {
             val streamId = frame.streamId
             val type = frame.type
-            if (streamId == 0) {
-                handleStreamZero(type, frame)
-            } else {
-                handleFrame(streamId, type, frame)
+            when (streamId) {
+                0 -> handleZeroFrame(type, frame)
+                else -> handleNonZeroFrame(streamId, type, frame)
             }
         } finally {
             frame.release()
         }
     }
 
-    private fun handleStreamZero(type: FrameType, frame: Frame) {
+    private fun handleZeroFrame(type: FrameType, frame: Frame) {
         when (type) {
             FrameType.ERROR -> throw Exceptions.from(frame)
             FrameType.LEASE -> {
@@ -395,95 +279,120 @@ internal class RSocketClient @JvmOverloads constructor(
                 timeLastTickSentMs = System.currentTimeMillis()
             }
             else ->
-                // Ignore unknown frames. Throwing an error will close the socket.
                 errorConsumer(
                         IllegalStateException(
                                 "Client received supported frame on stream 0: $frame"))
         }
     }
 
-    private fun handleFrame(streamId: Int, type: FrameType, frame: Frame) {
-        var receiver: Subscriber<Payload>? = null
-        synchronized(this) {
-            receiver = receivers.get(streamId)
-        }
-        if (receiver == null) {
-            handleMissingResponseProcessor(streamId, type, frame)
-        } else {
+    private fun handleNonZeroFrame(streamId: Int, type: FrameType, frame: Frame) {
+        receivers[streamId]?.let { receiver ->
             when (type) {
                 FrameType.ERROR -> {
-                    receiver!!.onError(Exceptions.from(frame))
-                    removeReceiver(streamId)
+                    receiver.onError(Exceptions.from(frame))
                 }
                 FrameType.NEXT_COMPLETE -> {
-                    receiver!!.onNext(PayloadImpl(frame))
-                    receiver!!.onComplete()
+                    receiver.onNext(PayloadImpl(frame))
+                    receiver.onComplete()
                 }
                 FrameType.CANCEL -> {
-                    var sender: LimitableRequestPublisher<*>? = null
-                    synchronized(this) {
-                        sender = senders.remove(streamId)
-                        removeReceiver(streamId)
-                    }
-                    if (sender != null) {
-                        sender!!.cancel()
-                    }
+                    val sender = senders.remove(streamId)
+                    sender?.cancel()
+                    receivers -= streamId
                 }
-                FrameType.NEXT -> receiver!!.onNext(PayloadImpl(frame))
+                FrameType.NEXT -> receiver.onNext(PayloadImpl(frame))
                 FrameType.REQUEST_N -> {
-                    var sender: LimitableRequestPublisher<*>? = null
-                    synchronized(this) {
-                        sender = senders.get(streamId)
-                    }
-                    if (sender != null) {
+                    val sender = senders[streamId]
+                    sender?.let {
                         val n = Frame.RequestN.requestN(frame).toLong()
-                        sender!!.increaseRequestLimit(n)
+                        it.request(n)
                     }
                 }
                 FrameType.COMPLETE -> {
-                    receiver!!.onComplete()
-                    synchronized(this) {
-                        receivers.remove(streamId)
-                    }
+                    receiver.onComplete()
                 }
-                else -> throw IllegalStateException(
-                        "Client received unsupported frame on stream $streamId : $frame")
+                else -> unsupportedFrame(streamId, frame)
             }
-        }
+        } ?: missingReceiver(streamId, type, frame)
     }
 
-    private fun handleMissingResponseProcessor(streamId: Int, type: FrameType, frame: Frame) {
+    private fun unsupportedFrame(streamId: Int, frame: Frame) {
+        errorConsumer(IllegalStateException(
+                "Client received unsupported frame on stream " +
+                        "$streamId : $frame"))
+    }
+
+    private fun missingReceiver(streamId: Int, type: FrameType, frame: Frame) {
         if (!streamIdSupplier.isBeforeOrCurrent(streamId)) {
-            if (type === FrameType.ERROR) {
-                // message for stream that has never existed, we have a problem with
-                // the overall connection and must tear down
-                val errorMessage = frame.dataUtf8
-
-                throw IllegalStateException(
-                        "Client received error for non-existent stream: $streamId Message: $errorMessage")
+            val err = if (type === FrameType.ERROR) {
+                IllegalStateException(
+                        "Client received error for non-existent stream: " +
+                                "$streamId Message: ${frame.dataUtf8}")
             } else {
-                throw IllegalStateException(
-                        "Client received message for non-existent stream: $streamId, frame type: $type")
+                IllegalStateException(
+                        "Client received message for non-existent stream: " +
+                                "$streamId, frame type: $type")
+            }
+            errorConsumer(err)
+        }
+    }
+
+    private inner class Interactions {
+        private val terminated = AtomicReference<Throwable>()
+
+        fun fireAndForget(request: Completable): Completable =
+                call(request) { Completable.error(it) }
+
+        fun requestResponse(request: Single<Payload>): Single<Payload> =
+                call(request) { Single.error(it) }
+
+        fun requestStream(request: Flowable<Payload>): Flowable<Payload> =
+                call(request) { Flowable.error(it) }
+
+        fun requestChannel(request: Flowable<Payload>): Flowable<Payload> =
+                call(request) { Flowable.error(it) }
+
+        fun metadataPush(request: Completable): Completable =
+                call(request) { Completable.error(it) }
+
+        private inline fun <T> call(arg: T, error: (Throwable) -> T) =
+                terminated.get()?.let { error(it) } ?: arg
+
+        fun complete() {
+            terminateOnce(closedException)
+        }
+
+        fun error(err: Throwable) {
+            terminateOnce(err)
+        }
+
+        private fun terminateOnce(err: Throwable) {
+            if (terminated.compareAndSet(null, err)) {
+                cleanUp(receivers) { it.onError(err) }
+                cleanUp(senders) { it.cancel() }
+                keepAliveSendSub?.dispose()
+                if (err !== closedException) {
+                    errorConsumer(err)
+                }
+
             }
         }
-        // receiving a frame after a given stream has been cancelled/completed,
-        // so ignore (cancellation is async so there is a race condition)
-    }
 
-    @Synchronized
-    private fun removeReceiver(streamId: Int) {
-        receivers.remove(streamId)
-    }
-
-    @Synchronized
-    private fun removeSender(streamId: Int) {
-        senders.remove(streamId)
+        private inline fun <T> cleanUp(map: MutableMap<Int, T>,
+                                       action: (T) -> Unit) {
+            map.values.forEach {
+                try {
+                    action(it)
+                } catch (t: Throwable) {
+                    errorConsumer(t)
+                }
+            }
+            map.clear()
+        }
     }
 
     companion object {
-        private val CLOSED_CHANNEL_EXCEPTION = noStacktrace(ClosedChannelException())
-        private val DEFAULT_STREAM_WINDOW = 128
+        private val closedException = noStacktrace(ClosedChannelException())
+        private fun <T> UnicastProcessor<T>.isTerminated() = hasComplete() or hasThrowable()
     }
-
-    private fun <T> UnicastProcessor<T>.isTerminated(): Boolean = hasComplete() || hasThrowable()
 }

--- a/rsocket-core/src/main/java/io/rsocket/android/frame/SetupFrameFlyweight.java
+++ b/rsocket-core/src/main/java/io/rsocket/android/frame/SetupFrameFlyweight.java
@@ -29,10 +29,9 @@ public class SetupFrameFlyweight {
 
   public static final int FLAGS_RESUME_ENABLE = 0b00_1000_0000;
   public static final int FLAGS_WILL_HONOR_LEASE = 0b00_0100_0000;
-  public static final int FLAGS_STRICT_INTERPRETATION = 0b00_0010_0000;
 
   public static final int VALID_FLAGS =
-      FLAGS_RESUME_ENABLE | FLAGS_WILL_HONOR_LEASE | FLAGS_STRICT_INTERPRETATION | FLAGS_M;
+      FLAGS_RESUME_ENABLE | FLAGS_WILL_HONOR_LEASE | FLAGS_M;
 
   public static final int CURRENT_VERSION = VersionFlyweight.encode(1, 0);
 

--- a/rsocket-core/src/main/java/io/rsocket/android/internal/LimitableRequestPublisher.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/internal/LimitableRequestPublisher.kt
@@ -24,9 +24,8 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-/**  */
 class LimitableRequestPublisher<T> private constructor(private val source: Publisher<T>)
-    : Flowable<T>(), Subscription,Disposable {
+    : Flowable<T>(), Subscription, Disposable {
 
     private val canceled: AtomicBoolean = AtomicBoolean()
     private var internalRequested: Long = 0

--- a/rsocket-core/src/main/java/io/rsocket/android/transport/TransportHeaderAware.kt
+++ b/rsocket-core/src/main/java/io/rsocket/android/transport/TransportHeaderAware.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-targetCompatibility = 1.7
-sourceCompatibility = 1.7
+package io.rsocket.android.transport
 
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.6"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.6"
+/**
+ * Extension interface to support Transports with headers at the transport layer, e.g. Websockets,
+ * Http2.
+ */
+interface TransportHeaderAware {
+    fun setTransportHeaders(transportHeaders: () -> Map<String, String>)
 }

--- a/rsocket-core/src/test/java/io/rsocket/android/RSocketTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/RSocketTest.kt
@@ -132,7 +132,8 @@ class RSocketTest {
             crs = RSocketClient(
                     clientConnection,
                     { throwable -> clientErrors.add(throwable) },
-                    StreamIdSupplier.clientSupplier())
+                    StreamIdSupplier.clientSupplier(),
+                    128)
         }
 
         fun setRequestAcceptor(requestAcceptor: RSocket) {

--- a/rsocket-core/src/test/java/io/rsocket/android/RequesterStreamWindowTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/RequesterStreamWindowTest.kt
@@ -39,7 +39,7 @@ class RequesterStreamWindowTest {
         val request = Flowable.just(1, 2, 3)
                 .map { PayloadImpl(it.toString()) as Payload }
                 .doOnRequest { demand = it }
-        rule.client.requestChannel(request).subscribe()
+        rule.client.requestChannel(request).subscribe({}, {})
         rule.receiver.onNext(Frame.RequestN.from(1, Int.MAX_VALUE))
         assertThat("requester channel handler is not limited",
                 demand,
@@ -47,7 +47,7 @@ class RequesterStreamWindowTest {
     }
 
     private fun checkRequesterInbound(f: Flowable<Payload>, type: FrameType) {
-        f.delaySubscription(100, TimeUnit.MILLISECONDS).subscribe()
+        f.delaySubscription(100, TimeUnit.MILLISECONDS).subscribe({}, {})
 
         val reqN = rule.sender.filter { it.type == type }
                 .firstOrError().blockingGet()

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/FrameHeaderFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/FrameHeaderFlyweightTest.kt
@@ -75,7 +75,7 @@ class FrameHeaderFlyweightTest {
     @Test
     fun dataLength() {
         val data = Unpooled.wrappedBuffer(byteArrayOf(1, 2, 3, 4, 5))
-        val length = FrameHeaderFlyweight.encode(
+        FrameHeaderFlyweight.encode(
                 byteBuf, 0, FLAGS_M, FrameType.SETUP, Unpooled.EMPTY_BUFFER, data)
         assertEquals(
                 5,

--- a/rsocket-core/src/test/java/io/rsocket/android/frame/KeepaliveFrameFlyweightTest.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/frame/KeepaliveFrameFlyweightTest.kt
@@ -28,7 +28,7 @@ class KeepaliveFrameFlyweightTest {
     @Test
     fun canReadData() {
         val data = Unpooled.wrappedBuffer(byteArrayOf(5, 4, 3))
-        val length = KeepaliveFrameFlyweight.encode(byteBuf, KeepaliveFrameFlyweight.FLAGS_KEEPALIVE_R, data)
+        KeepaliveFrameFlyweight.encode(byteBuf, KeepaliveFrameFlyweight.FLAGS_KEEPALIVE_R, data)
         data.resetReaderIndex()
 
         assertEquals(

--- a/rsocket-core/src/test/java/io/rsocket/android/test/util/TestDuplexConnection.kt
+++ b/rsocket-core/src/test/java/io/rsocket/android/test/util/TestDuplexConnection.kt
@@ -54,9 +54,9 @@ class TestDuplexConnection : DuplexConnection {
         }
         val subscriber = TestSubscriber.create<Frame>(initialSendRequestN.toLong())
         Flowable.fromPublisher(frame)
-                .doOnNext { frame ->
-                    sent.offer(frame)
-                    sentPublisher.onNext(frame)
+                .doOnNext { f ->
+                    sent.offer(f)
+                    sentPublisher.onNext(f)
                 }
                 .doOnError { throwable -> logger.error("Error in send stream on test connection.", throwable) }
                 .subscribe(subscriber)

--- a/rsocket-transport-netty/build.gradle
+++ b/rsocket-transport-netty/build.gradle
@@ -1,0 +1,14 @@
+repositories {
+    maven { url 'https://repo.spring.io/libs-snapshot' }
+}
+
+dependencies {
+    api project(":rsocket-core")
+    implementation ('io.projectreactor.ipc:reactor-netty:0.7.7.RELEASE')
+}
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/Ext.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/Ext.kt
@@ -1,0 +1,15 @@
+package io.rsocket.android.transport.netty
+
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Single
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+internal fun <T> Flux<T>.toFlowable(): Flowable<T> = Flowable.fromPublisher(this)
+
+internal fun Mono<Void>.toCompletable(): Completable = Completable.fromPublisher(this)
+
+internal fun <T> Mono<T>.toSingle(): Single<T> = Single.fromPublisher(this)
+
+internal fun Completable.toMono(): Mono<Void> = Mono.from(toFlowable())

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/NettyDuplexConnection.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/NettyDuplexConnection.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty
+
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
+import org.reactivestreams.Publisher
+import reactor.ipc.netty.NettyContext
+import reactor.ipc.netty.NettyInbound
+import reactor.ipc.netty.NettyOutbound
+
+class NettyDuplexConnection(private val inbound: NettyInbound,
+                            private val outbound: NettyOutbound,
+                            private val context: NettyContext) : DuplexConnection {
+
+    override fun send(frame: Publisher<Frame>): Completable =
+            Flowable.fromPublisher(frame)
+                    .concatMap { sendOne(it).toFlowable<Frame>() }
+                    .ignoreElements()
+
+    override fun sendOne(frame: Frame): Completable =
+            outbound.sendObject(frame.content()).then().toCompletable()
+
+    override fun receive(): Flowable<Frame> =
+            inbound.receive()
+                    .map { buf -> Frame.from(buf.retain()) }
+                    .toFlowable()
+
+    override fun availability(): Double = if (context.isDisposed) 0.0 else 1.0
+
+    override fun close(): Completable =
+            Completable.fromRunnable {
+                if (!context.isDisposed) {
+                    context.channel().close()
+                }
+            }
+
+    override fun onClose(): Completable =
+            context.onClose().toCompletable()
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/RSocketLengthCodec.java
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/RSocketLengthCodec.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+
+import static io.rsocket.android.frame.FrameHeaderFlyweight.FRAME_LENGTH_MASK;
+import static io.rsocket.android.frame.FrameHeaderFlyweight.FRAME_LENGTH_SIZE;
+
+public class RSocketLengthCodec extends LengthFieldBasedFrameDecoder {
+  public RSocketLengthCodec() {
+    super(FRAME_LENGTH_MASK, 0, FRAME_LENGTH_SIZE, 0, 0);
+  }
+
+  public Object decode(ByteBuf in) throws Exception {
+    return decode(null, in);
+  }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/WebsocketDuplexConnection.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/WebsocketDuplexConnection.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rsocket.android.transport.netty
+
+import io.netty.buffer.Unpooled.wrappedBuffer
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.Frame
+import io.rsocket.android.frame.FrameHeaderFlyweight
+import io.rsocket.android.frame.FrameHeaderFlyweight.FRAME_LENGTH_SIZE
+import org.reactivestreams.Publisher
+import reactor.ipc.netty.NettyContext
+import reactor.ipc.netty.NettyInbound
+import reactor.ipc.netty.NettyOutbound
+
+/**
+ * Implementation of a DuplexConnection for Websocket.
+ *
+ *
+ * rsocket-java strongly assumes that each Frame is encoded with the length. This is not true for
+ * message oriented transports so this must be specifically dropped from Frames sent and stitched
+ * back on for frames received.
+ */
+class WebsocketDuplexConnection(private val inbound: NettyInbound,
+                                private val outbound: NettyOutbound,
+                                private val context: NettyContext) : DuplexConnection {
+
+    override fun send(frame: Publisher<Frame>): Completable {
+        return Flowable.fromPublisher(frame)
+                .concatMap { sendOne(it).toFlowable<Frame>() }
+                .ignoreElements()
+    }
+
+    override fun sendOne(frame: Frame): Completable {
+        return outbound.sendObject(
+                BinaryWebSocketFrame(
+                        frame.content().skipBytes(FRAME_LENGTH_SIZE)))
+                .then()
+                .toCompletable()
+    }
+
+    override fun receive(): Flowable<Frame> {
+        return inbound.receive()
+                .map { buf ->
+                    val composite = context.channel().alloc().compositeBuffer()
+                    val length = wrappedBuffer(ByteArray(FRAME_LENGTH_SIZE))
+                    FrameHeaderFlyweight.encodeLength(length, 0, buf.readableBytes())
+                    composite.addComponents(true, length, buf.retain())
+                    Frame.from(composite)
+                }.toFlowable()
+    }
+
+    override fun availability(): Double = if (context.isDisposed) 0.0 else 1.0
+
+    override fun close(): Completable =
+            Completable.fromRunnable {
+                if (!context.isDisposed) {
+                    context.channel().close()
+                }
+            }
+
+    override fun onClose(): Completable = context.onClose().toCompletable()
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/client/TcpClientTransport.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/client/TcpClientTransport.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty.client
+
+import io.reactivex.Single
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.transport.ClientTransport
+import io.rsocket.android.transport.netty.NettyDuplexConnection
+import io.rsocket.android.transport.netty.RSocketLengthCodec
+import io.rsocket.android.transport.netty.toMono
+import reactor.ipc.netty.tcp.TcpClient
+import java.net.InetSocketAddress
+
+class TcpClientTransport private constructor(private val client: TcpClient)
+    : ClientTransport {
+
+    override fun connect(): Single<DuplexConnection> =
+            Single.create<DuplexConnection> { sink ->
+                client.newHandler { inbound, outbound ->
+                    inbound.context().addHandler(
+                            "client-length-codec",
+                            RSocketLengthCodec())
+
+                    val connection = NettyDuplexConnection(
+                            inbound,
+                            outbound,
+                            inbound.context())
+                    sink.onSuccess(connection)
+                    connection.onClose().toMono()
+                }.doOnError { sink.onError(it) }.subscribe()
+            }
+
+    companion object {
+
+        fun create(port: Int): TcpClientTransport {
+            val tcpClient = TcpClient.create(port)
+            return create(tcpClient)
+        }
+
+        fun create(bindAddress: String, port: Int): TcpClientTransport {
+            val tcpClient = TcpClient.create(bindAddress, port)
+            return create(tcpClient)
+        }
+
+        fun create(address: InetSocketAddress): TcpClientTransport {
+            val tcpClient = TcpClient.create(address.hostString, address.port)
+            return create(tcpClient)
+        }
+
+        fun create(client: TcpClient): TcpClientTransport {
+            return TcpClientTransport(client)
+        }
+    }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/client/WebsocketClientTransport.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/client/WebsocketClientTransport.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty.client
+
+import io.reactivex.Single
+import io.rsocket.android.DuplexConnection
+import io.rsocket.android.transport.ClientTransport
+import io.rsocket.android.transport.TransportHeaderAware
+import io.rsocket.android.transport.netty.WebsocketDuplexConnection
+import io.rsocket.android.transport.netty.toMono
+import reactor.ipc.netty.http.client.HttpClient
+import java.net.InetSocketAddress
+import java.net.URI
+
+class WebsocketClientTransport private constructor(private val client: HttpClient,
+                                                   private val path: String)
+    : ClientTransport, TransportHeaderAware {
+    private var transportHeaders: () -> Map<String, String> = { emptyMap() }
+
+    override fun connect(): Single<DuplexConnection> {
+        return Single.create<DuplexConnection> { sink ->
+            client.ws(path) { hb ->
+                transportHeaders().forEach { name, value -> hb.set(name, value) }
+            }.flatMap { response ->
+                response.receiveWebsocket { inbound, outbound ->
+                    val connection = WebsocketDuplexConnection(
+                            inbound,
+                            outbound,
+                            inbound.context())
+                    sink.onSuccess(connection)
+                    connection.onClose().toMono()
+                }
+            }.doOnError { sink.onError(it) }.subscribe()
+        }
+    }
+
+    override fun setTransportHeaders(transportHeaders: () -> Map<String, String>) {
+        this.transportHeaders = transportHeaders
+    }
+
+    companion object {
+
+        fun create(port: Int): WebsocketClientTransport {
+            val httpClient = HttpClient.create(port)
+            return create(httpClient, "/")
+        }
+
+        fun create(bindAddress: String, port: Int): WebsocketClientTransport {
+            val httpClient = HttpClient.create(bindAddress, port)
+            return create(httpClient, "/")
+        }
+
+        fun create(address: InetSocketAddress): WebsocketClientTransport {
+            return create(address.hostName, address.port)
+        }
+
+        fun create(uri: URI): WebsocketClientTransport {
+            val httpClient = createClient(uri)
+            return create(httpClient, uri.toString())
+        }
+
+        private fun createClient(uri: URI): HttpClient {
+            return if (isSecureWebsocket(uri)) {
+                HttpClient.create { options ->
+                    options.sslSupport()
+                            .connectAddress {
+                                InetSocketAddress.createUnresolved(
+                                        uri.host,
+                                        getPort(uri, 443))
+                            }
+                }
+            } else {
+                HttpClient.create(uri.host, getPort(uri, 80))
+            }
+        }
+
+        fun getPort(uri: URI, defaultPort: Int): Int {
+            return if (uri.port == -1) defaultPort else uri.port
+        }
+
+        fun isSecureWebsocket(uri: URI): Boolean {
+            return uri.scheme == "wss" || uri.scheme == "https"
+        }
+
+        fun isPlaintextWebsocket(uri: URI): Boolean {
+            return uri.scheme == "ws" || uri.scheme == "http"
+        }
+
+        fun create(client: HttpClient, path: String): WebsocketClientTransport {
+            return WebsocketClientTransport(client, path)
+        }
+    }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/NettyContextCloseable.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/NettyContextCloseable.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty.server
+
+import io.reactivex.Completable
+import io.rsocket.android.Closeable
+import io.rsocket.android.transport.netty.toCompletable
+import reactor.ipc.netty.NettyContext
+import java.net.InetSocketAddress
+
+/**
+ * A [Closeable] wrapping a [NettyContext], allowing for close and aware of its address.
+ */
+class NettyContextCloseable internal constructor(private val context: NettyContext)
+    : Closeable {
+    override fun close(): Completable =
+            Completable.fromRunnable {
+                if (!context.isDisposed) {
+                    context.channel().close()
+                }
+            }
+
+    override fun onClose(): Completable = context.onClose().toCompletable()
+
+    /**
+     * @see NettyContext.address
+     * @return socket address.
+     */
+    fun address(): InetSocketAddress = context.address()
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/TcpServerTransport.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/TcpServerTransport.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty.server
+
+import io.reactivex.Single
+import io.rsocket.android.transport.ServerTransport
+import io.rsocket.android.transport.netty.NettyDuplexConnection
+import io.rsocket.android.transport.netty.RSocketLengthCodec
+import io.rsocket.android.transport.netty.toSingle
+import reactor.ipc.netty.tcp.TcpServer
+import java.net.InetSocketAddress
+
+class TcpServerTransport private constructor(private var server: TcpServer)
+    : ServerTransport<NettyContextCloseable> {
+
+    override fun start(acceptor: ServerTransport.ConnectionAcceptor)
+            : Single<NettyContextCloseable> =
+            server.newHandler { inbound, outbound ->
+                inbound.context()
+                        .addHandler(
+                                "server-length-codec",
+                                RSocketLengthCodec())
+                val connection = NettyDuplexConnection(
+                        inbound,
+                        outbound,
+                        inbound.context())
+                acceptor(connection).subscribe()
+                outbound.neverComplete()
+            }.toSingle().map { NettyContextCloseable(it) }
+
+    companion object {
+
+        fun create(address: InetSocketAddress): TcpServerTransport {
+            val server = TcpServer.create(address.hostName, address.port)
+            return create(server)
+        }
+
+        fun create(bindAddress: String, port: Int): TcpServerTransport {
+            val server = TcpServer.create(bindAddress, port)
+            return create(server)
+        }
+
+        fun create(port: Int): TcpServerTransport {
+            val server = TcpServer.create(port)
+            return create(server)
+        }
+
+        fun create(server: TcpServer): TcpServerTransport {
+            return TcpServerTransport(server)
+        }
+    }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/WebsocketRouteTransport.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/WebsocketRouteTransport.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty.server
+
+import io.reactivex.Single
+import io.rsocket.android.Closeable
+import io.rsocket.android.transport.ServerTransport
+import io.rsocket.android.transport.ServerTransport.ConnectionAcceptor
+import io.rsocket.android.transport.netty.WebsocketDuplexConnection
+import io.rsocket.android.transport.netty.toSingle
+import reactor.core.publisher.Mono
+import reactor.ipc.netty.http.server.HttpServer
+import reactor.ipc.netty.http.server.HttpServerRoutes
+
+import java.util.function.Consumer
+
+class WebsocketRouteTransport(private val server: HttpServer,
+                              private val routesBuilder: (HttpServerRoutes) -> Unit,
+                              private val path: String) : ServerTransport<Closeable> {
+
+    override fun start(acceptor: ConnectionAcceptor): Single<Closeable> {
+        return server
+                .newRouter { routes ->
+                    routesBuilder(routes)
+                    routes.ws(path) { inbound, outbound ->
+                        val connection = WebsocketDuplexConnection(
+                                inbound,
+                                outbound,
+                                inbound.context())
+                        acceptor(connection).subscribe()
+                        outbound.neverComplete()
+                    }
+                }.toSingle().map { NettyContextCloseable(it) }
+    }
+}

--- a/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/WebsocketServerTransport.kt
+++ b/rsocket-transport-netty/src/main/java/io/rsocket/android/transport/netty/server/WebsocketServerTransport.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rsocket.android.transport.netty.server
+
+import io.reactivex.Single
+import io.rsocket.android.transport.ServerTransport
+import io.rsocket.android.transport.TransportHeaderAware
+import io.rsocket.android.transport.netty.WebsocketDuplexConnection
+import io.rsocket.android.transport.netty.toSingle
+import reactor.ipc.netty.http.server.HttpServer
+
+class WebsocketServerTransport private constructor(internal var server: HttpServer)
+    : ServerTransport<NettyContextCloseable>, TransportHeaderAware {
+    private var transportHeaders: () -> Map<String, String> = { emptyMap() }
+
+    override fun start(acceptor: ServerTransport.ConnectionAcceptor)
+            : Single<NettyContextCloseable> {
+        return server
+                .newHandler { _, response ->
+                    transportHeaders()
+                            .forEach { name, value -> response.addHeader(name, value) }
+                    response.sendWebsocket { inbound, outbound ->
+                        val connection =
+                                WebsocketDuplexConnection(
+                                        inbound,
+                                        outbound,
+                                        inbound.context())
+                        acceptor(connection).subscribe()
+                        outbound.neverComplete()
+                    }
+                }.toSingle().map { NettyContextCloseable(it) }
+    }
+
+    override fun setTransportHeaders(transportHeaders: () -> Map<String, String>) {
+        this.transportHeaders = transportHeaders
+    }
+
+    companion object {
+
+        fun create(bindAddress: String, port: Int): WebsocketServerTransport {
+            val httpServer = HttpServer.create(bindAddress, port)
+            return create(httpServer)
+        }
+
+        fun create(port: Int): WebsocketServerTransport {
+            val httpServer = HttpServer.create(port)
+            return create(httpServer)
+        }
+
+        fun create(server: HttpServer): WebsocketServerTransport {
+            return WebsocketServerTransport(server)
+        }
+    }
+}

--- a/rsocket-transport-okhttp/build.gradle
+++ b/rsocket-transport-okhttp/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
-    compile project(":rsocket-android-core")
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.10.0'
+    api project(":rsocket-core")
+    api 'com.squareup.okhttp3:okhttp:3.10.0'
 }
 
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.6"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.6"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,5 +17,8 @@ include ':rsocket-transport-okhttp'
 
 rootProject.name='rsocket-android'
 include 'rsocket-core'
-project(':rsocket-core').name = 'rsocket-android-core'
+project(':rsocket-core').name = 'rsocket-core'
 include 'rsocket-transport-okhttp'
+include 'rsocket-transport-netty'
+include 'test'
+

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+    testImplementation project(":rsocket-transport-okhttp")
+    testImplementation project(":rsocket-transport-netty")
+    testImplementation 'org.assertj:assertj-core:3.9.1'
+}
+
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}

--- a/test/src/test/kotlin/io/rsocket/android/test/ClientServerChannelTest.kt
+++ b/test/src/test/kotlin/io/rsocket/android/test/ClientServerChannelTest.kt
@@ -1,0 +1,98 @@
+package io.rsocket.android.test
+
+import io.reactivex.Flowable
+import io.reactivex.Single
+import io.rsocket.android.*
+import io.rsocket.android.transport.netty.client.TcpClientTransport
+import io.rsocket.android.transport.netty.server.NettyContextCloseable
+import io.rsocket.android.transport.netty.server.TcpServerTransport
+import io.rsocket.android.util.PayloadImpl
+import org.junit.Before
+import org.junit.Test
+import org.reactivestreams.Publisher
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class ClientServerChannelTest {
+    private lateinit var server: NettyContextCloseable
+    private lateinit var client: RSocket
+    private lateinit var channelHandler: ChannelHandler
+    @Before
+    fun setUp() {
+        val address = InetSocketAddress
+                .createUnresolved("localhost", 0)
+        val serverTransport = TcpServerTransport.create(address)
+
+        channelHandler = ChannelHandler(intervalMillis)
+        server = RSocketFactory
+                .receive()
+                .acceptor {
+                    object : SocketAcceptor {
+                        override fun accept(setup: ConnectionSetupPayload,
+                                            sendingSocket: RSocket): Single<RSocket> {
+                            return Single.just(channelHandler)
+                        }
+                    }
+                }.transport(serverTransport)
+                .start()
+                .blockingGet()
+
+        val clientTransport = TcpClientTransport
+                .create(server.address())
+
+        client = RSocketFactory
+                .connect()
+                .transport { clientTransport }
+                .start()
+                .blockingGet()
+    }
+
+    @Test
+    fun channel() {
+        var requestsCount = 0
+        client.requestChannel(textStream(intervalMillis))
+                .subscribe({ }, { throw it })
+
+        val delay = Flowable
+                .timer(5, TimeUnit.SECONDS)
+                .share()
+
+        Flowable.interval(250, TimeUnit.MILLISECONDS)
+                .takeUntil(delay)
+                .subscribe {
+                    val cur = channelHandler.counter()
+                    if (requestsCount == cur) {
+                        throw RuntimeException("Channel stream does not advance: $cur")
+                    }
+                    requestsCount = cur
+                }
+        delay.ignoreElements().blockingAwait()
+    }
+
+    internal class ChannelHandler(private val intervalMillis: Long)
+        : AbstractRSocket() {
+        private val counter = AtomicInteger()
+
+        fun counter() = counter.get()
+
+        override fun requestChannel(payloads: Publisher<Payload>):
+                Flowable<Payload> {
+            Flowable.fromPublisher(payloads)
+                    .subscribe(
+                            { counter.incrementAndGet() },
+                            { println("Server channel error: $it") })
+            return textStream(intervalMillis)
+        }
+
+    }
+
+    companion object {
+        internal fun textStream(intervalMillis: Long) =
+                Flowable.interval(intervalMillis, TimeUnit.MICROSECONDS)
+                        .onBackpressureDrop()
+                        .map { PayloadImpl.textPayload(it.toString()) }
+
+        internal const val intervalMillis: Long = 100
+    }
+}

--- a/test/src/test/kotlin/io/rsocket/android/test/EndToEndTest.kt
+++ b/test/src/test/kotlin/io/rsocket/android/test/EndToEndTest.kt
@@ -1,0 +1,200 @@
+package io.rsocket.android.test
+
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Single
+import io.rsocket.android.*
+import io.rsocket.android.transport.ClientTransport
+import io.rsocket.android.transport.ServerTransport
+import io.rsocket.android.transport.netty.server.NettyContextCloseable
+import io.rsocket.android.util.PayloadImpl
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.reactivestreams.Publisher
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+abstract class EndToEndTest
+(private val clientTransport: (InetSocketAddress) -> ClientTransport,
+ private val serverTransport: (InetSocketAddress) -> ServerTransport<NettyContextCloseable>) {
+    private lateinit var server: NettyContextCloseable
+    private lateinit var client: RSocket
+    private lateinit var handler: TestRSocketHandler
+    private val errors = Errors()
+
+    @Before
+    fun setUp() {
+        handler = TestRSocketHandler()
+        val address = InetSocketAddress
+                .createUnresolved("localhost", 0)
+
+        server = RSocketFactory
+                .receive()
+                .errorConsumer(errors.errorsConsumer())
+                .acceptor {
+                    object : SocketAcceptor {
+                        override fun accept(setup: ConnectionSetupPayload,
+                                            sendingSocket: RSocket): Single<RSocket> {
+                            return Single.just(handler)
+                        }
+                    }
+                }.transport(serverTransport(address))
+                .start()
+                .blockingGet()
+
+        client = RSocketFactory
+                .connect()
+                .errorConsumer(errors.errorsConsumer())
+                .transport { clientTransport(server.address()) }
+                .start()
+                .blockingGet()
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+                .andThen(server.onClose())
+                .blockingAwait(10, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun fireAndForget() {
+        val data = testData()
+        client.fireAndForget(data.payload())
+                .andThen(Completable.timer(1, TimeUnit.SECONDS))
+                .blockingAwait(10, TimeUnit.SECONDS)
+        assertThat(errors.errors()).isEmpty()
+        assertThat(handler.fireAndForgetData()).hasSize(1)
+                .contains(data)
+    }
+
+    @Test
+    fun response() {
+        val data = testData()
+        val response = client.requestResponse(data.payload())
+                .timeout(10, TimeUnit.SECONDS)
+                .blockingGet()
+        assertThat(errors.errors()).isEmpty()
+        assertThat(Data(response)).isEqualTo(data)
+    }
+
+    @Test
+    fun stream() {
+        val data = testData()
+        val response = client.requestStream(data.payload())
+                .timeout(10, TimeUnit.SECONDS)
+                .map { Data(it) }
+                .toList()
+                .blockingGet()
+        assertThat(errors.errors()).isEmpty()
+        assertThat(response).hasSize(1).contains(data)
+    }
+
+    @Test
+    fun channel() {
+        val data = testData()
+        val response = client.requestChannel(Flowable.just(data.payload()))
+                .timeout(10, TimeUnit.SECONDS)
+                .toList()
+                .blockingGet()
+        assertThat(errors.errors()).isEmpty()
+        assertThat(response).hasSize(1)
+        assertThat(Data(response[0])).isEqualTo(data)
+    }
+
+    @Test
+    fun metadataPush() {
+        val payload = PayloadImpl("", "md")
+        client.metadataPush(payload)
+                .andThen(Completable.timer(1, TimeUnit.SECONDS))
+                .timeout(10, TimeUnit.SECONDS)
+                .blockingAwait()
+
+        assertThat(errors.errors()).isEmpty()
+        assertThat(handler.metadataPushData())
+                .hasSize(1)
+                .contains("md")
+    }
+
+    @Test
+    open fun close() {
+        val success = client.close()
+                .andThen(client.onClose())
+                .blockingAwait(10, TimeUnit.SECONDS)
+        if (!success) {
+            throw IllegalStateException("RSocket.close() did not trigger RSocket.onClose()")
+        }
+    }
+
+    @Test
+    fun availability() {
+        assertThat(client.availability())
+                .isCloseTo(1.0, Offset.offset(1e-5))
+    }
+
+    @Test
+    open fun closedAvailability() {
+        client.close()
+                .andThen(client.onClose())
+                .timeout(10, TimeUnit.SECONDS)
+                .blockingAwait()
+
+        assertThat(client.availability())
+                .isCloseTo(0.0, Offset.offset(1e-5))
+    }
+
+
+    private fun testData() = Data("d", "md")
+
+    internal class TestRSocketHandler : AbstractRSocket() {
+        private val fnf = ArrayList<Data>()
+        private val metadata = ArrayList<String>()
+
+        override fun fireAndForget(payload: Payload): Completable {
+            fnf += Data(payload)
+            return Completable.complete()
+        }
+
+        override fun metadataPush(payload: Payload): Completable {
+            metadata += payload.metadataUtf8
+            return Completable.complete()
+        }
+
+        override fun requestResponse(payload: Payload): Single<Payload> {
+            return Single.just(payload)
+        }
+
+        override fun requestStream(payload: Payload): Flowable<Payload> {
+            return Flowable.just(payload)
+        }
+
+        override fun requestChannel(payloads: Publisher<Payload>): Flowable<Payload> {
+            return Flowable.fromPublisher(payloads)
+        }
+
+        fun fireAndForgetData() = fnf
+
+        fun metadataPushData() = metadata
+
+    }
+
+    internal class Errors {
+
+        private val errors = ArrayList<Throwable>()
+
+        fun errorsConsumer(): (Throwable) -> Unit = {
+            errors += (it)
+        }
+
+        fun errors() = errors
+    }
+
+    internal data class Data(val data: String, val metadata: String) {
+        constructor(payload: Payload) : this(payload.dataUtf8, payload.metadataUtf8)
+
+        fun payload(): Payload = PayloadImpl(data, metadata)
+    }
+}

--- a/test/src/test/kotlin/io/rsocket/android/test/NettyTcpEndToEndTest.kt
+++ b/test/src/test/kotlin/io/rsocket/android/test/NettyTcpEndToEndTest.kt
@@ -1,0 +1,9 @@
+package io.rsocket.android.test
+
+import io.rsocket.android.transport.netty.client.TcpClientTransport
+import io.rsocket.android.transport.netty.server.TcpServerTransport
+
+class NettyTcpEndToEndTest
+    : EndToEndTest(
+        { TcpClientTransport.create(it) },
+        { TcpServerTransport.create(it) })

--- a/test/src/test/kotlin/io/rsocket/android/test/NettyWebsocketEndToEndTest.kt
+++ b/test/src/test/kotlin/io/rsocket/android/test/NettyWebsocketEndToEndTest.kt
@@ -1,0 +1,16 @@
+package io.rsocket.android.test
+
+import io.rsocket.android.transport.netty.client.WebsocketClientTransport
+import io.rsocket.android.transport.netty.server.WebsocketServerTransport
+
+class NettyWebsocketEndToEndTest : EndToEndTest(
+        { WebsocketClientTransport.create(it) },
+        { WebsocketServerTransport.create(it.port) }) {
+
+    /*noop until https://github.com/reactor/reactor-netty/pull/346 is released*/
+    override fun close() {
+    }
+
+    override fun closedAvailability() {
+    }
+}

--- a/test/src/test/kotlin/io/rsocket/android/test/OkHttpNettyEndToEndTest.kt
+++ b/test/src/test/kotlin/io/rsocket/android/test/OkHttpNettyEndToEndTest.kt
@@ -1,0 +1,16 @@
+package io.rsocket.android.test
+
+import io.rsocket.android.transport.netty.server.WebsocketServerTransport
+import io.rsocket.transport.okhttp.client.OkhttpWebsocketClientTransport
+import okhttp3.HttpUrl
+
+class OkHttpNettyEndToEndTest : EndToEndTest(
+        {
+            OkhttpWebsocketClientTransport.create(
+                    HttpUrl.Builder()
+                            .host(it.hostName)
+                            .port(it.port)
+                            .scheme("http")
+                            .build())
+        },
+        { WebsocketServerTransport.create(it.hostName, it.port) })


### PR DESCRIPTION
added Netty transports: tcp, websockets

separate test module for integration testing

simplified RSocketClient and RSocketServer logic, fixed some issues around request-channel